### PR TITLE
Fix Typo Error Message for a null level

### DIFF
--- a/Uchu.Master/Api/AccountCommands.cs
+++ b/Uchu.Master/Api/AccountCommands.cs
@@ -114,7 +114,7 @@ namespace Uchu.Master.Api
 
             if (string.IsNullOrWhiteSpace(level))
             {
-                response.FailedReason = "username null";
+                response.FailedReason = "level null";
 
                 return response;
             }


### PR DESCRIPTION
Make it so a null level returns a message saying "level null" not "username null".

This can be tested by pulling from the API 

    curl "localhost:10000/account/level?u=name&l="