### PR TITLE
Further Correct GameMasterLevel Handling

### DIFF
--- a/Uchu.Core/Handlers/Commands/StandardCommandHandler.cs
+++ b/Uchu.Core/Handlers/Commands/StandardCommandHandler.cs
@@ -23,9 +23,9 @@ namespace Uchu.Core.Handlers.Commands
         public static string AddUser(string[] arguments)
         {
             if (arguments == null)
-                throw new ArgumentNullException(nameof(arguments), 
+                throw new ArgumentNullException(nameof(arguments),
                     ResourceStrings.StandardCommandHandler_AddUser_ArgumentsNullException);
-            
+
             if (arguments.Length != 1)
             {
                 return "adduser <name>";
@@ -68,9 +68,9 @@ namespace Uchu.Core.Handlers.Commands
         public static string RemoveUser(string[] arguments)
         {
             if (arguments == null)
-                throw new ArgumentNullException(nameof(arguments), 
+                throw new ArgumentNullException(nameof(arguments),
                     ResourceStrings.StandardCommandHandler_RemoveUser_ArgumentsNullException);
-            
+
             if (arguments.Length != 1)
             {
                 return "removeuser <name>";
@@ -100,9 +100,9 @@ namespace Uchu.Core.Handlers.Commands
         public static async Task<string> BanUser(string[] arguments)
         {
             if (arguments == null)
-                throw new ArgumentNullException(nameof(arguments), 
+                throw new ArgumentNullException(nameof(arguments),
                     ResourceStrings.StandardCommandHandler_BanUser_ArgumentsNullException);
-            
+
             if (arguments.Length != 2)
             {
                 return $"{arguments[0]} <name> <reason>";
@@ -133,9 +133,9 @@ namespace Uchu.Core.Handlers.Commands
         public static async Task<string> PardonUser(string[] arguments)
         {
             if (arguments == null)
-                throw new ArgumentNullException(nameof(arguments), 
+                throw new ArgumentNullException(nameof(arguments),
                     ResourceStrings.StandardCommandHandler_PardonUser_ArgumentsNullException);
-            
+
             if (arguments.Length != 1)
             {
                 return $"{arguments[0]} <name>";
@@ -176,9 +176,9 @@ namespace Uchu.Core.Handlers.Commands
         public static async Task<string> ApproveUsernames(string[] arguments)
         {
             if (arguments == null)
-                throw new ArgumentNullException(nameof(arguments),  
+                throw new ArgumentNullException(nameof(arguments),
                     ResourceStrings.StandardCommandHandler_ApproveUsername_ArgumentsNullException);
-            
+
             await using var ctx = new UchuContext();
             if (arguments.Length == 0 || arguments[0].ToLower() == "*" || string.IsNullOrEmpty(arguments[0]))
             {
@@ -225,9 +225,9 @@ namespace Uchu.Core.Handlers.Commands
         public static async Task<string> RejectUserNames(string[] arguments)
         {
             if (arguments == null)
-                throw new ArgumentNullException(nameof(arguments), 
+                throw new ArgumentNullException(nameof(arguments),
                     ResourceStrings.StandardCommandHandler_RejectUserNames_ArgumentsNullException);
-            
+
             await using var ctx = new UchuContext();
             if (arguments.Length == 0 || arguments[0].ToLower() == "all")
             {
@@ -267,9 +267,9 @@ namespace Uchu.Core.Handlers.Commands
         public static async Task<string> SetGameMasterLevel(string[] arguments)
         {
             if (arguments == null)
-                throw new ArgumentNullException(nameof(arguments), 
+                throw new ArgumentNullException(nameof(arguments),
                     ResourceStrings.StandardCommandHandler_SetGameMasterLevel_ArgumentsNullException);
-            
+
             if (arguments.Length != 2)
             {
                 return "gamemaster <username> <level>";

--- a/Uchu.Core/Handlers/Commands/StandardCommandHandler.cs
+++ b/Uchu.Core/Handlers/Commands/StandardCommandHandler.cs
@@ -286,24 +286,18 @@ namespace Uchu.Core.Handlers.Commands
                 return $"No user with the username of: {username}";
             }
 
-            if (!Enum.TryParse<GameMasterLevel>(arguments[1], out var level))
+            if (!Enum.TryParse<GameMasterLevel>(arguments[1], out var level) ||
+                !Enum.IsDefined(typeof(GameMasterLevel), level))
             {
                 return "Invalid <level>";
             }
-            
-            if (Enum.IsDefined(typeof(GameMasterLevel), int.Parse(arguments[1])))
-            {
-                user.GameMasterLevel = (int) level;
 
-                await ctx.SaveChangesAsync().ConfigureAwait(false);
+            user.GameMasterLevel = (int) level;
 
-                return$"Successfully set {user.Username}'s Game Master " +
-                      $"level to {(GameMasterLevel) user.GameMasterLevel}";
-            }
-            else
-            {
-                return "Invalid <level>";
-            }
+            await ctx.SaveChangesAsync().ConfigureAwait(false);
+
+            return$"Successfully set {user.Username}'s Game Master " +
+                  $"level to {(GameMasterLevel) user.GameMasterLevel}";
         }
 
         private static string GetPassword()

--- a/Uchu.Master/Api/AccountCommands.cs
+++ b/Uchu.Master/Api/AccountCommands.cs
@@ -18,14 +18,14 @@ namespace Uchu.Master.Api
             if (string.IsNullOrWhiteSpace(accountName))
             {
                 response.FailedReason = "username null";
-                
+
                 return response;
             }
 
             if (string.IsNullOrWhiteSpace(accountPassword))
             {
                 response.FailedReason = "password null";
-                
+
                 return response;
             }
 
@@ -36,10 +36,10 @@ namespace Uchu.Master.Api
                 if (duplicate)
                 {
                     response.FailedReason = "duplicate username";
-                    
+
                     return response;
                 }
-                
+
                 var password = BCrypt.Net.BCrypt.EnhancedHashPassword(accountPassword);
 
                 await ctx.Users.AddAsync(new User
@@ -62,7 +62,7 @@ namespace Uchu.Master.Api
                 response.Username = user.Username;
                 response.Hash = user.Password;
             }
-            
+
             return response;
         }
 
@@ -77,7 +77,7 @@ namespace Uchu.Master.Api
 
                 return response;
             }
-            
+
             await using (var ctx = new UchuContext())
             {
                 var user = await ctx.Users.FirstOrDefaultAsync(u => u.Username == accountName);
@@ -99,12 +99,12 @@ namespace Uchu.Master.Api
 
             return response;
         }
-        
+
         [ApiCommand("account/level")]
         public async Task<object> AdminAccount(string accountName, string level)
         {
             var response = new AccountAdminResponse();
-            
+
             if (string.IsNullOrWhiteSpace(accountName))
             {
                 response.FailedReason = "username null";
@@ -133,7 +133,7 @@ namespace Uchu.Master.Api
                 if (!Enum.TryParse<GameMasterLevel>(level, out var gameMasterLevel))
                 {
                     response.FailedReason = "invalid level";
-                    
+
                     return response;
                 }
 
@@ -192,7 +192,7 @@ namespace Uchu.Master.Api
 
             return response;
         }
-        
+
         [ApiCommand("account/pardon")]
         public async Task<object> PardonAccount(string accountName)
         {
@@ -204,7 +204,7 @@ namespace Uchu.Master.Api
 
                 return response;
             }
-            
+
             await using (var ctx = new UchuContext())
             {
                 var user = await ctx.Users.FirstOrDefaultAsync(u => u.Username == accountName);
@@ -267,7 +267,7 @@ namespace Uchu.Master.Api
         public async Task<object> Accounts()
         {
             var response = new AccountListResponse();
-            
+
             await using var ctx = new UchuContext();
 
             response.Success = true;

--- a/Uchu.Master/Api/AccountCommands.cs
+++ b/Uchu.Master/Api/AccountCommands.cs
@@ -129,8 +129,9 @@ namespace Uchu.Master.Api
 
                     return response;
                 }
-                
-                if (!Enum.TryParse<GameMasterLevel>(level, out var gameMasterLevel))
+
+                if (!Enum.TryParse<GameMasterLevel>(level, out var gameMasterLevel) ||
+                    !Enum.IsDefined(typeof(GameMasterLevel), gameMasterLevel))
                 {
                     response.FailedReason = "invalid level";
 


### PR DESCRIPTION
Corrects a new error that is caused by trying to specify the text of an enum at the console. This corrects it by properly parsing the text.

Also added handling to check GameMasterLevel values coming from the API