### PR TITLE
Allow pre-made names again

### DIFF
--- a/Uchu.Char/Handlers/CharacterHandler.cs
+++ b/Uchu.Char/Handlers/CharacterHandler.cs
@@ -111,7 +111,8 @@ namespace Uchu.Char.Handlers
 
             await using (var ctx = new UchuContext())
             {
-                if (ctx.Characters.Any(c => c.Name == packet.CharacterName || c.CustomName == packet.CharacterName))
+                if (!string.IsNullOrEmpty(packet.CharacterName) 
+                    && ctx.Characters.Any(c => c.Name == packet.CharacterName || c.CustomName == packet.CharacterName))
                 {
                     Logger.Debug($"{connection} character create rejected due to duplicate name");
                     connection.Send(new CharacterCreateResponse


### PR DESCRIPTION
This checks if a custom name is actually requested before checking for duplicates (otherwise it sees every character without a pending name as a duplicate, and tells the client 'We're sorry, "" is already in use' when no custom name is specified).

The issue this fixes was ironically created in #130, which solved another situation causing the 'We're sorry, "" is already in use' message to appear when a user tries to create a character with 3 predefined name parts.