### PR TITLE
Add Authorization Port Configuration

### DIFF
--- a/Uchu.Core/Config/UchuConfiguration.cs
+++ b/Uchu.Core/Config/UchuConfiguration.cs
@@ -159,6 +159,11 @@ namespace Uchu.Core.Config
         [XmlElement] public string Hostname { get; set; } = "";
         
         /// <summary>
+        /// The port to run the authentication server at
+        /// </summary>
+        [XmlElement] public int AuthenticationPort { get; set; } = 21836;
+        
+        /// <summary>
         /// The port to run the character server at
         /// </summary>
         [XmlElement] public int CharacterPort { get; set; } = 2002;

--- a/Uchu.Core/Handlers/General/GeneralHandler.cs
+++ b/Uchu.Core/Handlers/General/GeneralHandler.cs
@@ -17,13 +17,10 @@ namespace Uchu.Core.Handlers
             {
                 Logger.Warning($"Handshake attempted with client of Game version: {packet.GameVersion}");
             }
-            
-            // TODO: Use resource / setting
-            const int port = 21836;
 
             connection.Send(new HandshakePacket
             {
-                ConnectionType = UchuServer.Port == port ? 0x01u : 0x04u,
+                ConnectionType = UchuServer.Port == UchuServer.Config.Networking.AuthenticationPort ? 0x01u : 0x04u,
                 Address = UchuServer.Host
             });
         }

--- a/Uchu.Master/MasterServer.cs
+++ b/Uchu.Master/MasterServer.cs
@@ -163,7 +163,7 @@ namespace Uchu.Master
 
             if (hostAuthentication)
             {
-                await StartInstanceAsync(ServerType.Authentication, 21836);
+                await StartInstanceAsync(ServerType.Authentication, Config.Networking.AuthenticationPort);
             }
 
             if (hostCharacter)


### PR DESCRIPTION
Related (already closed) issue: https://github.com/UchuServer/Uchu/issues/152

This change allows the server owner to configure the port used by the Authorization server from the hardcoded 21836 to an arbitrary port. This may not get much use given it requires users to explicitly define the port and use the next release of lcdr's RakNet shim, but does reduce a hardcoded number that requires a code change if someone really needed a custom port.

The change was tested with the arbitrary port 20000 using the latest code from lcdr's RakNet shim repository using `cargo build --release` to build. It was also tested in the stock configuration (port 21836). Both cases allowed me to log in, select a character, and play in Avant Gardens.