### PR TITLE
Improve Maelstrom Vacuum

### DIFF
--- a/Uchu.StandardScripts/AvantGardens/MaelstromVacuum.cs
+++ b/Uchu.StandardScripts/AvantGardens/MaelstromVacuum.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Numerics;
 using System.Threading.Tasks;
@@ -16,27 +17,55 @@ namespace Uchu.StandardScripts.AvantGardens
                 if (!(obj is AuthoredGameObject gameObject)) return;
                 
                 if (gameObject.Lot != 14596) return;
-
-                var samples = Zone.GameObjects.Where(g => g.Lot == 14718).ToList();
-
-                var position = gameObject.Transform.Position;
-
-                samples.Sort((a, b) => (int) (
-                    Vector3.Distance(position, a.Transform.Position) -
-                    Vector3.Distance(position, b.Transform.Position)
-                ));
-
-                var selected = samples.FirstOrDefault();
                 
-                if (selected == default) return;
+                if (!(gameObject.Author is Player player)) return;
 
-                if (Vector3.Distance(position, selected.Transform.Position) > 15) return;
-
-                var smashable = selected.GetComponent<DestructibleComponent>();
-
-                Task.Run(async () =>
+                Delegate onFireServerEventDelegate = null;
+                onFireServerEventDelegate = Listen(player.OnFireServerEvent, (name, message) =>
                 {
-                    await smashable.SmashAsync(gameObject, gameObject.Author as Player);
+                    if (name != "attemptCollection") return;
+                    
+                    if (message.Associate != gameObject) return;
+                    
+                    ReleaseListener(onFireServerEventDelegate);
+                    
+                    var samples = Zone.GameObjects.Where(g => g.Lot == 14718).ToList();
+
+                    var position = gameObject.Transform.Position;
+
+                    samples.Sort((a, b) => (int) (
+                        Vector3.Distance(position, a.Transform.Position) -
+                        Vector3.Distance(position, b.Transform.Position)
+                    ));
+
+                    var selected = samples.FirstOrDefault();
+
+                    if (selected == default) return;
+
+                    if (Vector3.Distance(position, selected.Transform.Position) > 15) return;
+
+                    var smashable = selected.GetComponent<DestructibleComponent>();
+                    
+                    Task.Run(async () =>
+                    {
+                        gameObject.Animate("collect_maelstrom");
+                        
+                        await Task.Delay(4000);
+
+                        await smashable.SmashAsync(gameObject, gameObject.Author as Player);
+                    });
+                });
+
+                Delegate onReadyForUpdatesEventDelegate = null;
+                onReadyForUpdatesEventDelegate = Listen(player.OnReadyForUpdatesEvent, (message) =>
+                {
+                    if (message.GameObject.Lot != 14596) return;
+                    
+                    if (message.GameObject != gameObject) return;
+                    
+                    ReleaseListener(onReadyForUpdatesEventDelegate);
+                    
+                    message.GameObject.Animate("idle_maelstrom");
                 });
             });
             

--- a/Uchu.StandardScripts/AvantGardens/MaelstromVacuum.cs
+++ b/Uchu.StandardScripts/AvantGardens/MaelstromVacuum.cs
@@ -11,7 +11,7 @@ namespace Uchu.StandardScripts.AvantGardens
     {
         public override Task LoadAsync()
         {
-            Listen(Zone.OnObject, async obj =>
+            Listen(Zone.OnObject, obj =>
             {
                 if (!(obj is AuthoredGameObject gameObject)) return;
                 
@@ -34,7 +34,10 @@ namespace Uchu.StandardScripts.AvantGardens
 
                 var smashable = selected.GetComponent<DestructibleComponent>();
 
-                await smashable.SmashAsync(gameObject, gameObject.Author as Player);
+                Task.Run(async () =>
+                {
+                    await smashable.SmashAsync(gameObject, gameObject.Author as Player);
+                });
             });
             
             return Task.CompletedTask;

--- a/Uchu.World/Handlers/GameMessages/GeneralHandler.cs
+++ b/Uchu.World/Handlers/GameMessages/GeneralHandler.cs
@@ -68,9 +68,10 @@ namespace Uchu.World.Handlers.GameMessages
         }
 
         [PacketHandler]
-        public void ReadyForUpdatesHandler(ReadyForUpdateMessage message, Player player)
+        public async Task ReadyForUpdatesHandler(ReadyForUpdateMessage message, Player player)
         {
             Logger.Debug($"Loaded: {message.GameObject}");
+            await player.OnReadyForUpdatesEvent.InvokeAsync(message);
         }
 
         [PacketHandler]

--- a/Uchu.World/Objects/GameObjects/Player.cs
+++ b/Uchu.World/Objects/GameObjects/Player.cs
@@ -24,6 +24,7 @@ namespace Uchu.World
         {
             OnRespondToMission = new Event<int, GameObject, Lot>();
             OnFireServerEvent = new Event<string, FireServerEventMessage>();
+            OnReadyForUpdatesEvent = new Event<ReadyForUpdateMessage>();
             OnPositionUpdate = new Event<Vector3, Quaternion>();
             OnLootPickup = new Event<Lot>();
             OnWorldLoad = new Event();
@@ -80,6 +81,8 @@ namespace Uchu.World
         }
 
         public Event<string, FireServerEventMessage> OnFireServerEvent { get; }
+        
+        public Event<ReadyForUpdateMessage> OnReadyForUpdatesEvent { get; }
 
         public Event<int, GameObject, Lot> OnRespondToMission { get; }
 


### PR DESCRIPTION
*Closes #66 and #80*

This pull request resolves a bug that the Maelstrom vacuum could only pick up 1 sample without rebooting, with the server tick processing sometimes stopping, as well as adding the missing animations for not being in range and actually collecting.