### PR TITLE
Add Restarting Missions

### DIFF
--- a/Uchu.Core/Database/UchuContext.cs
+++ b/Uchu.Core/Database/UchuContext.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Uchu.Core.Providers;
 
 namespace Uchu.Core
@@ -58,6 +59,11 @@ namespace Uchu.Core
                     Logger.Error($"{config.Database.Provider} is a invalid or unsupported database provider");
                     throw new Exception($"Invalid database provider: \"{config.Database.Provider}\"");
             }
+        }
+        
+        public EntityEntry Entry(object entry)
+        {
+            return ContextBase.Entry(entry);
         }
         
         public async Task EnsureUpdatedAsync()

--- a/Uchu.StandardScripts/AvantGardens/LaserRampageReturn.cs
+++ b/Uchu.StandardScripts/AvantGardens/LaserRampageReturn.cs
@@ -15,7 +15,7 @@ namespace Uchu.StandardScripts.AvantGardens
 
                 Listen(missionInventory.OnCompleteMission, instance =>
                 {
-                    if (instance.MissionId != 1854 || instance.MissionId != 1873) return;
+                    if (instance.MissionId != 1854 && instance.MissionId != 1873) return;
                     
                     if (!player.TryGetComponent<InventoryManagerComponent>(out var inventoryManager)) return;
 

--- a/Uchu.World/Objects/Components/Player/MissionInventoryComponent.cs
+++ b/Uchu.World/Objects/Components/Player/MissionInventoryComponent.cs
@@ -317,7 +317,7 @@ namespace Uchu.World
         /// <param name="mission"></param>
         /// <returns><c>true</c> if the player can accept this mission, <c>false</c> otherwise</returns>
         public bool CanAccept(MissionInstance mission) => 
-            (mission.Repeatable || !HasMission(mission.MissionId)) 
+            (mission.CanRepeat || !HasMission(mission.MissionId)) 
             && MissionParser.CheckPrerequiredMissions(mission.PrerequisiteMissions, AllMissions);
         
         /// <summary>
@@ -370,6 +370,13 @@ namespace Uchu.World
             {
                 mission = await AddMissionAsync(missionId, GameObject);
                 await mission.StartAsync();
+                return;
+            }
+            
+            // Repeat the mission if it is repeatable, such as a daily mission.
+            if (mission.CanRepeat)
+            {
+                await mission.RestartAsync();
                 return;
             }
             

--- a/Uchu.World/Objects/Components/Player/MissionInventoryComponent.cs
+++ b/Uchu.World/Objects/Components/Player/MissionInventoryComponent.cs
@@ -196,7 +196,7 @@ namespace Uchu.World
         /// <param name="mission"></param>
         /// <returns><c>true</c> if the player can accept this mission, <c>false</c> otherwise</returns>
         public bool CanAccept(MissionInstance mission) => 
-            (mission.Repeatable || !HasMission(mission.MissionId)) 
+            (mission.CanRepeat || !HasMission(mission.MissionId)) 
             && MissionParser.CheckPrerequiredMissions(mission.PrerequisiteMissions, CompletedMissions);
         
         /// <summary>

--- a/Uchu.World/Objects/Components/Player/MissionInventoryComponent.cs
+++ b/Uchu.World/Objects/Components/Player/MissionInventoryComponent.cs
@@ -260,6 +260,13 @@ namespace Uchu.World
                 return;
             }
             
+            // Repeat the mission if it is repeatable, such as a daily mission.
+            if (mission.CanRepeat)
+            {
+                await mission.RestartAsync(uchuContext);
+                return;
+            }
+            
             // Player is responding to an active mission.
             if (!mission.Completed)
             {

--- a/Uchu.World/Objects/Components/Server/MissionGiverComponent.cs
+++ b/Uchu.World/Objects/Components/Server/MissionGiverComponent.cs
@@ -124,6 +124,9 @@ namespace Uchu.World
                             case MissionState.ReadyToComplete:
                             case MissionState.Unavailable:
                             case MissionState.Completed:
+                                // Allow the mission if it is repeatable and the cooldown period has passed.
+                                if (!playerMission.CanRepeat) continue;
+                                break;
                             case MissionState.CompletedReadyToComplete:
                                 // Any other missions are skipped
                                 continue;

--- a/Uchu.World/Systems/Missions/MissionInstance.cs
+++ b/Uchu.World/Systems/Missions/MissionInstance.cs
@@ -395,6 +395,11 @@ namespace Uchu.World.Systems.Missions
             Repeatable = mission.Repeatable ?? false;
             InMissionOfTheDay = mission.InMOTD ?? false;
             CooldownTime = mission.CooldownTime ?? 0;
+            if (InMissionOfTheDay && CooldownTime == 0)
+            {
+                // Prevents infinite loop of getting and completing daily quest. ~22 hour timer is used by other daily quests.
+                CooldownTime = 1300;
+            }
             
             // Possible stat rewards
             RewardMaxHealth = mission.Rewardmaxhealth ?? 0;

--- a/Uchu.World/Systems/Missions/MissionTaskInstance.cs
+++ b/Uchu.World/Systems/Missions/MissionTaskInstance.cs
@@ -238,5 +238,13 @@ namespace Uchu.World.Systems.Missions
             if (Mission.Completed)
                 await Mission.SoftCompleteAsync();
         }
+        
+        /// <summary>
+        /// Restarts the task status.
+        /// </summary>
+        public void Restart()
+        {
+            this.Progress = new List<float>();
+        }
     }
 }


### PR DESCRIPTION
Closes https://github.com/UchuServer/Uchu/issues/169

This pull request adds the ability to restart completed missions, such as daily missions or helper missions in Nexus Tower. This also includes a fix for a bug I introduced with returning items in the Laser Rampage/Wrecking Crew not working due to a wrong condition operator.

The change was developed on `enhancement/reduce-load-time` and the changes were moved over to a different branch. The changes were tested by manually changing the completion time of a daily mission (id 1858 especially) in the database to be an older time to allow for the mission to be re-obtained. The mission was re-obtained, re-completed, and the incrementer in the database of how many times it completed went up.