### PR TITLE
Perform Temporary Caching

### DIFF
--- a/Uchu.Core/Config/UchuConfiguration.cs
+++ b/Uchu.Core/Config/UchuConfiguration.cs
@@ -90,6 +90,14 @@ namespace Uchu.Core.Config
     public class CacheConfig
     {
         /// <summary>
+        /// Whether to use an external caching service, like Redis.
+        /// Setting to false reduces the initial server load times
+        /// if no service is installed and the connection will
+        /// always timeout.
+        /// </summary>
+        [XmlElement] public bool UseService { get; set; } = true;
+        
+        /// <summary>
         /// Hostname to use when connecting to the cache service
         /// </summary>
         [XmlElement]

--- a/Uchu.Core/Logging/LogQueue.cs
+++ b/Uchu.Core/Logging/LogQueue.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Uchu.Core
+{
+    public class LogEntry
+    {
+        public string message { get; set; }
+        public ConsoleColor color { get; set; }
+        public LogEntry nextEntry { get; set; }
+    }
+    
+    public class LogQueue : IDisposable
+    {
+        private readonly Mutex logMutex = new Mutex();
+        private LogEntry nextEntry = null;
+        private LogEntry lastEntry = null;
+        
+        /// <summary>
+        /// Adds a line to the log queue.
+        /// </summary>
+        public void AddLine(string line, ConsoleColor color)
+        {
+            // Lock the log.
+            logMutex.WaitOne();
+            
+            // Create the new entry.
+            var entry = new LogEntry()
+            {
+                message = line,
+                color = color,
+            };
+            
+            // Update the pointers.
+            if (this.nextEntry == null)
+            {
+                this.nextEntry = entry;
+                this.lastEntry = entry;
+            }
+            else
+            {
+                this.lastEntry.nextEntry = entry;
+                this.lastEntry = entry;
+            }
+
+            // Unlock the log.
+            this.logMutex.ReleaseMutex();
+        }
+
+        /// <summary>
+        /// Pops the next entry to output.
+        /// Returns null if there is no pending entry.
+        /// </summary>
+        public LogEntry PopEntry()
+        {
+            // Lock the log.
+            logMutex.WaitOne();
+            
+            // Pop the next entry.
+            LogEntry entry = null;
+            if (this.nextEntry != null)
+            {
+                entry = this.nextEntry;
+                this.nextEntry = entry.nextEntry;
+            }
+            
+            // Unlock the log.
+            this.logMutex.ReleaseMutex();
+            
+            // Return the entry.
+            return entry;
+        }
+
+        /// <summary>
+        /// Starts a thread for outputting the log. This prevents
+        /// the console IO from blocking the application.
+        /// </summary>
+        public void StartConsoleOutput()
+        {
+            Task.Factory.StartNew(async () =>
+            {
+                // Run the output loop.
+                while (true)
+                {
+                    // Read the entries until they are exhausted.
+                    var entry = this.PopEntry();
+                    while (entry != null)
+                    {
+                        // Set the color to output.
+                        if (entry.color == ConsoleColor.White)
+                        {
+                            Console.ResetColor();
+                        }
+                        else
+                        {
+                            Console.ForegroundColor = entry.color;
+                        }
+                        
+                        // Write the entry.
+                        await Console.Out.WriteLineAsync(entry.message).ConfigureAwait(false);
+                        entry = this.PopEntry();
+                    }
+                    
+                    // Reset the color.
+                    Console.ResetColor();
+                    
+                    // Sleep for a bit before resuming.
+                    await Task.Delay(50).ConfigureAwait(false);
+                }
+            },CancellationToken.None,TaskCreationOptions.LongRunning,TaskScheduler.Default);
+        }
+        
+        /// <summary>
+        /// Disposed the object.
+        /// Implemented to silence CA1001 warning.
+        /// </summary>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                this.logMutex.Dispose();
+            }
+        }
+
+        /// <summary>
+        /// Disposed the object.
+        /// Implemented to silence CA1001 warning.
+        /// </summary>
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/Uchu.Core/Logging/Logger.cs
+++ b/Uchu.Core/Logging/Logger.cs
@@ -12,6 +12,10 @@ namespace Uchu.Core
     {
         public static UchuConfiguration Config { get; set; }
 
+        private static LogQueue logQueue = new LogQueue();
+
+        private static bool outputTaskStarted = false;
+
         public static void Log(object content, LogLevel logLevel = LogLevel.Information)
         {
             switch (logLevel)
@@ -110,15 +114,6 @@ namespace Uchu.Core
             }
 
             {
-                if (color == ConsoleColor.White)
-                {
-                    Console.ResetColor();
-                }
-                else
-                {
-                    Console.ForegroundColor = color;
-                }
-
                 var level = logLevel.ToString();
 
                 var padding = new string(Enumerable.Repeat(' ', 12 - level.Length).ToArray());
@@ -148,10 +143,14 @@ namespace Uchu.Core
 
                 if (consoleLogLevel <= logLevel)
                 {
-                    finalMessage = configuration.Timestamp ? $"[{DateTime.Now}] {message}" : message;
+                    finalMessage = configuration.Timestamp ? $"[{GetCurrentTime()}] {message}" : message;
+                    logQueue.AddLine(finalMessage,color);
 
-                    Console.WriteLine(finalMessage);
-                    Console.ResetColor();
+                    if (!outputTaskStarted)
+                    {
+                        outputTaskStarted = true;
+                        logQueue.StartConsoleOutput();
+                    }
                 }
 
                 configuration = Config.FileLogging;
@@ -162,10 +161,15 @@ namespace Uchu.Core
 
                 var file = configuration.File;
 
-                finalMessage = configuration.Timestamp ? $"[{DateTime.Now}] {message}" : message;
+                finalMessage = configuration.Timestamp ? $"[{GetCurrentTime()}] {message}" : message;
 
                 File.AppendAllTextAsync(file, $"{finalMessage}\n");
             }
+        }
+
+        public static string GetCurrentTime()
+        {
+            return DateTime.Now.ToString("MM/dd/yyyy hh:mm:ss.fff tt");
         }
 
 #if DEBUG

--- a/Uchu.Core/UchuServer.cs
+++ b/Uchu.Core/UchuServer.cs
@@ -208,14 +208,22 @@ namespace Uchu.Core
             SsoService = new SsoService(Config.SsoConfig?.Domain ?? "");
 
             // Try to connect to Redis, otherwise fallback to DB caching
-            try
+            if (Config.CacheConfig.UseService)
             {
-                SessionCache = new RedisSessionCache(Config.CacheConfig);
-                Logger.Information($"Established Redis connection at {Config.CacheConfig.Host}:{Config.CacheConfig.Port}");
+                try
+                {
+                    SessionCache = new RedisSessionCache(Config.CacheConfig);
+                    Logger.Information($"Established Redis connection at {Config.CacheConfig.Host}:{Config.CacheConfig.Port}");
+                }
+                catch (RedisConnectionException)
+                {
+                    Logger.Error("Failed to establish Redis connection, falling back to database.");
+                    SessionCache = new DatabaseCache();
+                }
             }
-            catch (RedisConnectionException)
+            else
             {
-                Logger.Error("Failed to establish Redis connection, falling back to database.");
+                Logger.Information("Caching service is disabled, falling back to database.");
                 SessionCache = new DatabaseCache();
             }
 

--- a/Uchu.StandardScripts/BlockYard/BlockYardProperty.cs
+++ b/Uchu.StandardScripts/BlockYard/BlockYardProperty.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System;
 using InfectedRose.Luz;
 using System.Numerics;
+using Uchu.World.Client;
 
 namespace Uchu.StandardScripts.BlockYard
 {
@@ -189,8 +190,7 @@ namespace Uchu.StandardScripts.BlockYard
 
                 SpiderQueen.Animate("withdraw");
 
-                using var cdClient = new CdClientContext();
-                var Animation = cdClient.AnimationsTable.FirstOrDefault(
+                var Animation = ClientCache.GetTable<Animations>().FirstOrDefault(
                     a => a.Animationname == "withdraw"
                 );
 

--- a/Uchu.StandardScripts/General/LaunchpadEvent.cs
+++ b/Uchu.StandardScripts/General/LaunchpadEvent.cs
@@ -1,8 +1,10 @@
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Uchu.Core;
 using Uchu.Core.Client;
 using Uchu.World;
+using Uchu.World.Client;
 using Uchu.World.Scripting.Native;
 
 namespace Uchu.StandardScripts.General
@@ -19,11 +21,9 @@ namespace Uchu.StandardScripts.General
                     {
                         var launchpad = message.Associate.GetComponent<RocketLaunchpadComponent>();
 
-                        await using var cdClient = new CdClientContext();
-
                         var id = launchpad.GameObject.Lot.GetComponentId(ComponentId.RocketLaunchComponent);
 
-                        var launchpadComponent = await cdClient.RocketLaunchpadControlComponentTable.FirstOrDefaultAsync(
+                        var launchpadComponent = (await ClientCache.GetTableAsync<RocketLaunchpadControlComponent>()).FirstOrDefault(
                             r => r.Id == id
                         );
 

--- a/Uchu.World/Client/CdClient/ClientCache.cs
+++ b/Uchu.World/Client/CdClient/ClientCache.cs
@@ -1,5 +1,9 @@
+using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
 using Uchu.Core;
 using Uchu.Core.Client;
 using Uchu.World.Systems.Missions;
@@ -12,6 +16,11 @@ namespace Uchu.World.Client
     public static class ClientCache
     {
         /// <summary>
+        /// Cache of the table objects used by GetTable and GetTableAsync
+        /// </summary>
+        private static Dictionary<string,object> cacheTables = new Dictionary<string,object>();
+        
+        /// <summary>
         /// All missions in the cd client
         /// </summary>
         public static MissionInstance[] Missions { get; private set; } = { };
@@ -21,17 +30,18 @@ namespace Uchu.World.Client
         /// </summary>
         public static MissionInstance[] Achievements { get; private set; } = { };
 
+        /// <summary>
+        /// Loads the initial cache
+        /// </summary>
         public static async Task LoadAsync()
         {
-            await using var cdContext = new CdClientContext();
-
             Logger.Debug("Setting up missions cache");
-            var missionTasks = cdContext.MissionsTable
+            var missionTasks = GetTable<Missions>()
                 .ToArray()
                 .Select(async m =>
                 {
                     var instance = new MissionInstance(m.Id ?? 0);
-                    await instance.LoadAsync(cdContext);
+                    await instance.LoadAsync();
                     return instance;
                 }).ToList();
 
@@ -39,6 +49,29 @@ namespace Uchu.World.Client
             
             Missions = missionTasks.Select(t => t.Result).ToArray();
             Achievements = Missions.Where(m => !m.IsMission).ToArray();
+        }
+
+        /// <summary>
+        /// Fetches the values of a table asynchronously.
+        /// Will return without waiting if the data is already stored.
+        /// </summary>
+        public static async Task<T[]> GetTableAsync<T>() where T : class
+        {
+            var tableName = typeof(T).Name + "Table";
+            if (!cacheTables.ContainsKey(tableName))
+            {
+                cacheTables[tableName] = new TableCache<T>(tableName);
+            }
+
+            return await ((TableCache<T>) cacheTables[tableName]).GetValuesAsync();
+        }
+
+        /// <summary>
+        /// Fetches the values of a table.
+        /// </summary>
+        public static T[] GetTable<T>() where T : class
+        {
+            return GetTableAsync<T>().Result;
         }
     }
 }

--- a/Uchu.World/Client/CdClient/TableCache.cs
+++ b/Uchu.World/Client/CdClient/TableCache.cs
@@ -13,11 +13,11 @@ namespace Uchu.World.Client
     /// </summary>
     public class TableCache<T> where T : class
     {
-        private PropertyInfo cdClientContextProperty;
-        private T[] cachedData;
-        private long lastAccessTime = 0;
-        private bool clearDataQueued = false;
-        private int clearTimeMilliseconds = 3000;
+        private PropertyInfo CdClientContextProperty;
+        private T[] CachedData;
+        private long LastAccessTime = 0;
+        private bool ClearDataQueued = false;
+        private int ClearTimeMilliseconds = 3000;
         
         /// <summary>
         /// Creates the table cache.
@@ -28,12 +28,12 @@ namespace Uchu.World.Client
             foreach (var property in typeof(CdClientContext).GetProperties())
             {
                 if (property.Name != tableName) continue;
-                cdClientContextProperty = property;
+                CdClientContextProperty = property;
                 break;
             }
             
             // Throw an exception if the table name is invalid.
-            if (cdClientContextProperty == null)
+            if (CdClientContextProperty == null)
             {
                 throw new InvalidOperationException("Table name doesn't exist: " + tableName);
             }
@@ -45,23 +45,23 @@ namespace Uchu.World.Client
         public async Task<T[]> GetValuesAsync()
         {
             // Update the last access time and fetch the data if it isn't stored.
-            lastAccessTime = DateTimeOffset.Now.ToUnixTimeSeconds();
-            if (cachedData == default)
+            LastAccessTime = DateTimeOffset.Now.ToUnixTimeSeconds();
+            if (CachedData == default)
             {
                 // Fetch the data.
                 await using var cdContext = new CdClientContext();
-                cachedData = ((DbSet<T>) cdClientContextProperty.GetValue(cdContext))?.ToArray();
+                CachedData = ((DbSet<T>) CdClientContextProperty.GetValue(cdContext))?.ToArray();
 
                 // Queue clearing the data.
-                if (!clearDataQueued)
+                if (!ClearDataQueued)
                 {
-                    clearDataQueued = true;
+                    ClearDataQueued = true;
                     Task.Run(ClearQueueTimeAsync);
                 }
             }
 
             // Return the cached data.
-            return cachedData;
+            return CachedData;
         }
 
         /// <summary>
@@ -73,13 +73,13 @@ namespace Uchu.World.Client
             while (true)
             {
                 // Wait the delay before checking to clear the table.
-                var startLastAccessTime = lastAccessTime;
-                await Task.Delay(clearTimeMilliseconds);
+                var startLastAccessTime = LastAccessTime;
+                await Task.Delay(ClearTimeMilliseconds);
 
                 // Clear the table if it hasn't been accessed recently.
-                if (startLastAccessTime != lastAccessTime) continue;
-                cachedData = default;
-                clearDataQueued = false;
+                if (startLastAccessTime != LastAccessTime) continue;
+                CachedData = default;
+                ClearDataQueued = false;
                 GC.Collect();
                 return;
             }

--- a/Uchu.World/Client/CdClient/TableCache.cs
+++ b/Uchu.World/Client/CdClient/TableCache.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Uchu.Core.Client;
+
+namespace Uchu.World.Client
+{
+    /// <summary>
+    /// Temporarily caches data for when a lot of client database
+    /// reads are done at once, such as when the world starts.
+    /// </summary>
+    public class TableCache<T> where T : class
+    {
+        private PropertyInfo cdClientContextProperty;
+        private T[] cachedData;
+        private long lastAccessTime = 0;
+        private bool clearDataQueued = false;
+        private int clearTimeMilliseconds = 3000;
+        
+        /// <summary>
+        /// Creates the table cache.
+        /// </summary>
+        public TableCache(string tableName)
+        {
+            // Get the CdClient property info for fetching.
+            foreach (var property in typeof(CdClientContext).GetProperties())
+            {
+                if (property.Name != tableName) continue;
+                cdClientContextProperty = property;
+                break;
+            }
+            
+            // Throw an exception if the table name is invalid.
+            if (cdClientContextProperty == null)
+            {
+                throw new InvalidOperationException("Table name doesn't exist: " + tableName);
+            }
+        }
+
+        /// <summary>
+        /// Returns the values of the table asynchronously.
+        /// </summary>
+        public async Task<T[]> GetValuesAsync()
+        {
+            // Update the last access time and fetch the data if it isn't stored.
+            lastAccessTime = DateTimeOffset.Now.ToUnixTimeSeconds();
+            if (cachedData == default)
+            {
+                // Fetch the data.
+                await using var cdContext = new CdClientContext();
+                cachedData = ((DbSet<T>) cdClientContextProperty.GetValue(cdContext))?.ToArray();
+
+                // Queue clearing the data.
+                if (!clearDataQueued)
+                {
+                    clearDataQueued = true;
+                    Task.Run(ClearQueueTimeAsync);
+                }
+            }
+
+            // Return the cached data.
+            return cachedData;
+        }
+
+        /// <summary>
+        /// Queues clearing the cached data to save memory
+        /// after a period of the data not being read from.
+        /// </summary>
+        private async void ClearQueueTimeAsync()
+        {
+            while (true)
+            {
+                // Wait the delay before checking to clear the table.
+                var startLastAccessTime = lastAccessTime;
+                await Task.Delay(clearTimeMilliseconds);
+
+                // Clear the table if it hasn't been accessed recently.
+                if (startLastAccessTime != lastAccessTime) continue;
+                cachedData = default;
+                clearDataQueued = false;
+                GC.Collect();
+                return;
+            }
+        }
+    }
+}

--- a/Uchu.World/Client/ZoneParser.cs
+++ b/Uchu.World/Client/ZoneParser.cs
@@ -35,9 +35,7 @@ namespace Uchu.World.Client
 
             Logger.Information("Parsing zone info...");
             
-            await using var ctx = new CdClientContext();
-            
-            var zone = ctx.ZoneTableTable.FirstOrDefault(zone => zone.ZoneID == seek);
+            var zone = (await ClientCache.GetTableAsync<ZoneTable>()).FirstOrDefault(zone => zone.ZoneID == seek);
                 
             if (zone == default)
             {

--- a/Uchu.World/Handlers/Commands/CharacterCommandHandler.cs
+++ b/Uchu.World/Handlers/Commands/CharacterCommandHandler.cs
@@ -12,6 +12,7 @@ using System.IO;
 using Uchu.Core;
 using Uchu.Core.Client;
 using Uchu.Core.Resources;
+using Uchu.World.Client;
 using Uchu.World.Filters;
 using Uchu.World.Scripting.Native;
 using Uchu.World.Social;
@@ -748,9 +749,7 @@ namespace Uchu.World.Handlers.Commands
 
             if (!int.TryParse(arguments[0], out var id)) return "Invalid <zoneId>";
 
-            using CdClientContext ctx = new CdClientContext();
-
-            ZoneTable WorldTable = ctx.ZoneTableTable.FirstOrDefault(t => t.ZoneID == id);
+            ZoneTable WorldTable = ClientCache.GetTable<ZoneTable>().FirstOrDefault(t => t.ZoneID == id);
 
             if (WorldTable == default)
             {
@@ -888,17 +887,15 @@ namespace Uchu.World.Handlers.Commands
             if (arguments.Length == default)
                 return "getemote <emote>";
 
-            await using var cdClient = new CdClientContext();
-
             Emotes emote;
             
             if (int.TryParse(arguments[0], out var id))
             {
-                emote = await cdClient.EmotesTable.FirstOrDefaultAsync(c => c.Id == id);
+                emote = (await ClientCache.GetTableAsync<Emotes>()).FirstOrDefault(c => c.Id == id);
             }
             else
             {
-                emote = await cdClient.EmotesTable.FirstOrDefaultAsync(c => c.AnimationName == arguments[0].ToLower());
+                emote = (await ClientCache.GetTableAsync<Emotes>()).FirstOrDefault(c => c.AnimationName == arguments[0].ToLower());
             }
 
             if (emote?.Id == default)

--- a/Uchu.World/Handlers/GameMessages/GeneralHandler.cs
+++ b/Uchu.World/Handlers/GameMessages/GeneralHandler.cs
@@ -1,7 +1,9 @@
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Uchu.Core;
 using Uchu.Core.Client;
+using Uchu.World.Client;
 
 namespace Uchu.World.Handlers.GameMessages
 {
@@ -77,9 +79,7 @@ namespace Uchu.World.Handlers.GameMessages
         [PacketHandler]
         public async Task PlayEmoteHandler(PlayEmoteMessage message, Player player)
         {
-            await using var ctx = new CdClientContext();
-
-            var animation = await ctx.EmotesTable.FirstOrDefaultAsync(e => e.Id == message.EmoteId);
+            var animation = (await ClientCache.GetTableAsync<Emotes>()).FirstOrDefault(e => e.Id == message.EmoteId);
             
             player.Zone.BroadcastMessage(new PlayAnimationMessage
             {
@@ -109,13 +109,12 @@ namespace Uchu.World.Handlers.GameMessages
         public async Task NotifyServerLevelProcessingCompleteHandler(NotifyServerLevelProcessingCompleteMessage message, Player player)
         {
             await using var ctx = new UchuContext();
-            await using var cdClient = new CdClientContext();
 
             var character = await ctx.Characters.FirstAsync(c => c.Id == player.Id);
 
             var lookup_val = 0;
 
-            foreach (var levelProgressionLookup in cdClient.LevelProgressionLookupTable)
+            foreach (var levelProgressionLookup in (await ClientCache.GetTableAsync<LevelProgressionLookup>()))
             {
                 if (levelProgressionLookup.RequiredUScore > character.UniverseScore) break;
 

--- a/Uchu.World/Handlers/WorldInitializationHandler.cs
+++ b/Uchu.World/Handlers/WorldInitializationHandler.cs
@@ -10,6 +10,7 @@ using Microsoft.EntityFrameworkCore;
 using RakDotNet;
 using Uchu.Core;
 using Uchu.Core.Client;
+using Uchu.World.Client;
 
 namespace Uchu.World.Handlers
 {
@@ -331,7 +332,6 @@ namespace Uchu.World.Handlers
         private static FlagNode[] FlagNodes(Character character)
         {
             var flags = new Dictionary<int, FlagNode>();
-            using var cdContext = new CdClientContext();
 
             /*
             // Keep a list of all tasks ids that belong to flag tasks
@@ -427,8 +427,7 @@ namespace Uchu.World.Handlers
                     var progressNodes = new List<MissionProgressNode>
                         {new MissionProgressNode {Value = task.Values.Sum(v => v.Count)}};
 
-                    using var cdClient = new CdClientContext();
-                    var cdTask = cdClient.MissionTasksTable.First(t => t.Uid == task.TaskId);
+                    var cdTask = ClientCache.GetTable<MissionTasks>().First(t => t.Uid == task.TaskId);
 
                     // If the task type is collectible, also send all collectible ids
                     if (cdTask.TaskType != null && ((MissionTaskType) cdTask.TaskType) == MissionTaskType.Collect)

--- a/Uchu.World/Objects/Components/DestroyableComponent.cs
+++ b/Uchu.World/Objects/Components/DestroyableComponent.cs
@@ -5,6 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using RakDotNet.IO;
 using Uchu.Core;
 using Uchu.Core.Client;
+using Uchu.World.Client;
 
 namespace Uchu.World
 {
@@ -213,11 +214,9 @@ namespace Uchu.World
             {
                 if (GameObject is Player) CollectPlayerStats();
                 else CollectObjectStats();
-                
-                await using var cdClient = new CdClientContext();
 
                 var componentId = GameObject.Lot.GetComponentId(ComponentId.DestructibleComponent);
-                var destroyable = cdClient.DestructibleComponentTable.FirstOrDefault(
+                var destroyable = (await ClientCache.GetTableAsync<Core.Client.DestructibleComponent>()).FirstOrDefault(
                     c => c.Id == componentId
                 );
                 
@@ -227,7 +226,7 @@ namespace Uchu.World
 
                 Smashable = destroyable.IsSmashable ?? false;
 
-                var faction = await cdClient.FactionsTable.FirstOrDefaultAsync(
+                var faction = (await ClientCache.GetTableAsync<Factions>()).FirstOrDefault(
                     f => f.Faction == Factions[0]
                 );
                 
@@ -380,10 +379,8 @@ namespace Uchu.World
 
         private void CollectObjectStats()
         {
-            using var cdClient = new CdClientContext();
-
             var componentId = GameObject.Lot.GetComponentId(ComponentId.DestructibleComponent);
-            var stats = cdClient.DestructibleComponentTable.FirstOrDefault(
+            var stats = ClientCache.GetTable<Core.Client.DestructibleComponent>().FirstOrDefault(
                 o => o.Id == componentId
             );
 

--- a/Uchu.World/Objects/Components/DestroyableComponent.cs
+++ b/Uchu.World/Objects/Components/DestroyableComponent.cs
@@ -216,8 +216,9 @@ namespace Uchu.World
                 
                 await using var cdClient = new CdClientContext();
 
+                var componentId = GameObject.Lot.GetComponentId(ComponentId.DestructibleComponent);
                 var destroyable = cdClient.DestructibleComponentTable.FirstOrDefault(
-                    c => c.Id == GameObject.Lot.GetComponentId(ComponentId.DestructibleComponent)
+                    c => c.Id == componentId
                 );
                 
                 if (destroyable == default) return;
@@ -381,8 +382,9 @@ namespace Uchu.World
         {
             using var cdClient = new CdClientContext();
 
+            var componentId = GameObject.Lot.GetComponentId(ComponentId.DestructibleComponent);
             var stats = cdClient.DestructibleComponentTable.FirstOrDefault(
-                o => o.Id == GameObject.Lot.GetComponentId(ComponentId.DestructibleComponent)
+                o => o.Id == componentId
             );
 
             if (stats == default) return;

--- a/Uchu.World/Objects/Components/Player/InventoryManagerComponent.cs
+++ b/Uchu.World/Objects/Components/Player/InventoryManagerComponent.cs
@@ -8,6 +8,7 @@ using Microsoft.EntityFrameworkCore;
 using Uchu.Core;
 using Uchu.Core.Client;
 using Uchu.Core.Resources;
+using Uchu.World.Client;
 
 namespace Uchu.World
 {
@@ -122,9 +123,7 @@ namespace Uchu.World
         
         public async Task AddItemAsync(Lot lot, uint count, LegoDataDictionary extraInfo = default)
         {
-            await using var cdClient = new CdClientContext();
-            
-            var componentId = await cdClient.ComponentsRegistryTable.FirstOrDefaultAsync(
+            var componentId = (await ClientCache.GetTableAsync<ComponentsRegistry>()).FirstOrDefault(
                 r => r.Id == lot && r.Componenttype == (int) ComponentId.ItemComponent
             );
 
@@ -134,7 +133,7 @@ namespace Uchu.World
                 return;
             }
 
-            var component = await cdClient.ItemComponentTable.FirstOrDefaultAsync(
+            var component = (await ClientCache.GetTableAsync<ItemComponent>()).FirstOrDefault(
                 i => i.Id == componentId.Componentid
             );
 
@@ -181,10 +180,7 @@ namespace Uchu.World
             }
 
             // The math here cannot be executed in parallel
-            
-            await using var cdClient = new CdClientContext();
-            
-            var componentId = cdClient.ComponentsRegistryTable.FirstOrDefault(
+            var componentId = (await ClientCache.GetTableAsync<ComponentsRegistry>()).FirstOrDefault(
                 r => r.Id == lot && r.Componenttype == (int) ComponentId.ItemComponent
             );
 
@@ -194,7 +190,7 @@ namespace Uchu.World
                 return;
             }
 
-            var component = cdClient.ItemComponentTable.FirstOrDefault(
+            var component = (await ClientCache.GetTableAsync<ItemComponent>()).FirstOrDefault(
                 i => i.Id == componentId.Componentid
             );
 
@@ -273,9 +269,7 @@ namespace Uchu.World
         {
             if (count == default) return;
             
-            await using var cdClient = new CdClientContext();
-            
-            var componentId = await cdClient.ComponentsRegistryTable.FirstOrDefaultAsync(
+            var componentId = (await ClientCache.GetTableAsync<ComponentsRegistry>()).FirstOrDefault(
                 r => r.Id == lot && r.Componenttype == (int) ComponentId.ItemComponent
             );
 
@@ -285,7 +279,7 @@ namespace Uchu.World
                 return;
             }
 
-            var component = await cdClient.ItemComponentTable.FirstOrDefaultAsync(
+            var component = (await ClientCache.GetTableAsync<ItemComponent>()).FirstOrDefault(
                 i => i.Id == componentId.Componentid
             );
 
@@ -306,10 +300,8 @@ namespace Uchu.World
         public void RemoveItem(int lot, uint count, InventoryType inventoryType, bool silent = false)
         {
             OnLotRemoved.Invoke(lot, count);
-
-            using var cdClient = new CdClientContext();
             
-            var componentId = cdClient.ComponentsRegistryTable.FirstOrDefault(
+            var componentId = ClientCache.GetTable<ComponentsRegistry>().FirstOrDefault(
                 r => r.Id == lot && r.Componenttype == (int) ComponentId.ItemComponent
             );
 
@@ -319,7 +311,7 @@ namespace Uchu.World
                 return;
             }
 
-            var component = cdClient.ItemComponentTable.FirstOrDefault(
+            var component = ClientCache.GetTable<ItemComponent>().FirstOrDefault(
                 i => i.Id == componentId.Componentid
             );
 

--- a/Uchu.World/Objects/Components/Player/MissionInventoryComponent.cs
+++ b/Uchu.World/Objects/Components/Player/MissionInventoryComponent.cs
@@ -94,7 +94,6 @@ namespace Uchu.World
         {
             if (GameObject is Player player)
             {
-                await using var cdContext = new CdClientContext();
                 await using var uchuContext = new UchuContext();
 
                 // On load, load all the missions from database and store them in memory
@@ -107,7 +106,7 @@ namespace Uchu.World
                 foreach (var mission in missions)
                 {
                     var instance = new MissionInstance(mission.MissionId);
-                    await instance.LoadAsync(cdContext, uchuContext, player);
+                    await instance.LoadAsync(uchuContext, player);
 
                     lock (Missions)
                     {
@@ -248,10 +247,8 @@ namespace Uchu.World
             // If the user doesn't have this mission yet, start it
             if (mission == default)
             {
-                await using var cdContext = new CdClientContext();
-
                 var instance = new MissionInstance(missionId);
-                await instance.LoadAsync(cdContext, uchuContext, (Player)GameObject);
+                await instance.LoadAsync(uchuContext, (Player)GameObject);
                 
                 lock (Missions) {
                     Missions.Add(instance);
@@ -289,10 +286,8 @@ namespace Uchu.World
             // If the player is completing a mission that hasn't started, start it first
             if (mission == default)
             {
-                await using var cdContext = new CdClientContext();
-                
                 var instance = new MissionInstance(missionId);
-                await instance.LoadAsync(cdContext, uchuContext, (Player)GameObject);
+                await instance.LoadAsync(uchuContext, (Player)GameObject);
                 await instance.CompleteAsync(uchuContext);
                 
                 lock (Missions)
@@ -552,11 +547,10 @@ namespace Uchu.World
                 // Loading these here instead of out of the loop might seem odd but heuristically the chances of starting a
                 // new achievement are much lower than not starting an achievement, that's why doing this in the loop
                 // allows us to open less db transactions in the long run
-                await using var cdContext = new CdClientContext();
                 await using var uchuContext = new UchuContext();
                 
                 var instance = new MissionInstance(achievement.MissionId);
-                await instance.LoadAsync(cdContext, uchuContext, (Player)GameObject);
+                await instance.LoadAsync(uchuContext, (Player)GameObject);
                 
                 lock (Missions)
                 {

--- a/Uchu.World/Objects/Components/ReplicaComponents/BaseCombatAIComponent.cs
+++ b/Uchu.World/Objects/Components/ReplicaComponents/BaseCombatAIComponent.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using RakDotNet.IO;
 using Uchu.Core.Client;
+using Uchu.World.Client;
 using Uchu.World.Systems.AI;
 
 namespace Uchu.World
@@ -57,9 +58,7 @@ namespace Uchu.World
 
                     foreach (var skillEntry in SkillComponent.DefaultSkillSet)
                     {
-                        await using var ctx = new CdClientContext();
-
-                        var skillInfo = await ctx.SkillBehaviorTable.FirstAsync(
+                        var skillInfo = (await ClientCache.GetTableAsync<SkillBehavior>()).First(
                             s => s.SkillID == skillEntry.SkillId
                         );
 

--- a/Uchu.World/Objects/Components/ReplicaComponents/DestructibleComponent.cs
+++ b/Uchu.World/Objects/Components/ReplicaComponents/DestructibleComponent.cs
@@ -6,6 +6,7 @@ using RakDotNet.IO;
 using Uchu.Core;
 using Uchu.Core.Client;
 using Uchu.Core.Resources;
+using Uchu.World.Client;
 
 namespace Uchu.World
 {
@@ -55,17 +56,15 @@ namespace Uchu.World
                 
                 GameObject.Layer = StandardLayer.Smashable;
 
-                await using (var cdClient = new CdClientContext())
-                {
-                    var entry = GameObject.Lot.GetComponentId(ComponentId.DestructibleComponent);
+                var entry = GameObject.Lot.GetComponentId(ComponentId.DestructibleComponent);
 
-                    var cdClientComponent = cdClient.DestructibleComponentTable.FirstOrDefault(
-                        c => c.Id == entry
-                    );
+                var cdClientComponent = (await ClientCache.GetTableAsync<Core.Client.DestructibleComponent>()).FirstOrDefault(
+                    c => c.Id == entry
+                );
 
-                    if (cdClientComponent == default)
-                        Logger.Error($"{GameObject} has a corrupt Destructible Component of id: {entry}");
-                }
+                if (cdClientComponent == default)
+                    Logger.Error($"{GameObject} has a corrupt Destructible Component of id: {entry}");
+                
 
                 if (GameObject.TryGetComponent(out DestroyableComponent stats))
                 {

--- a/Uchu.World/Objects/Components/ReplicaComponents/InventoryComponent.cs
+++ b/Uchu.World/Objects/Components/ReplicaComponents/InventoryComponent.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore;
 using RakDotNet.IO;
 using Uchu.Core;
 using Uchu.Core.Client;
+using Uchu.World.Client;
 
 namespace Uchu.World
 {
@@ -37,12 +38,10 @@ namespace Uchu.World
             {
                 if (GameObject is Player) return;
                 
-                using var cdClient = new CdClientContext();
-                
-                var component = cdClient.ComponentsRegistryTable.FirstOrDefault(c =>
+                var component = ClientCache.GetTable<ComponentsRegistry>().FirstOrDefault(c =>
                     c.Id == GameObject.Lot && c.Componenttype == (int) ComponentId.InventoryComponent);
 
-                var items = cdClient.InventoryComponentTable.Where(i => i.Id == component.Componentid).ToArray();
+                var items = ClientCache.GetTable<Core.Client.InventoryComponent>().Where(i => i.Id == component.Componentid).ToArray();
 
                 foreach (var item in items)
                 {
@@ -52,7 +51,7 @@ namespace Uchu.World
 
                     var componentId = lot.GetComponentId(ComponentId.ItemComponent);
 
-                    var info = cdClient.ItemComponentTable.First(i => i.Id == componentId);
+                    var info = ClientCache.GetTable<ItemComponent>().First(i => i.Id == componentId);
                     
                     var location = (EquipLocation) info.EquipLocation;
                     
@@ -86,11 +85,9 @@ namespace Uchu.World
 
         public async Task EquipAsync(EquippedItem item)
         {
-            await using var cdClient = new CdClientContext();
-
             var componentId = item.Lot.GetComponentId(ComponentId.ItemComponent);
 
-            var info = await cdClient.ItemComponentTable.FirstAsync(i => i.Id == componentId);
+            var info = (await ClientCache.GetTableAsync<ItemComponent>()).First(i => i.Id == componentId);
             
             var location = (EquipLocation) info.EquipLocation;
 
@@ -115,7 +112,7 @@ namespace Uchu.World
                 
                 componentId = lot.GetComponentId(ComponentId.ItemComponent);
 
-                info = await cdClient.ItemComponentTable.FirstOrDefaultAsync(i => i.Id == componentId);
+                info = (await ClientCache.GetTableAsync<ItemComponent>()).FirstOrDefault(i => i.Id == componentId);
             
                 if (info == default) continue;
                 
@@ -226,9 +223,7 @@ namespace Uchu.World
 
         private static async Task<Lot[]> ParseProxyItemsAsync(Lot item)
         {
-            await using var ctx = new CdClientContext();
-
-            var itemInfo = await ctx.ItemComponentTable.FirstOrDefaultAsync(
+            var itemInfo = (await ClientCache.GetTableAsync<ItemComponent>()).FirstOrDefault(
                 i => i.Id == item.GetComponentId(ComponentId.ItemComponent)
             );
 

--- a/Uchu.World/Objects/Components/ReplicaComponents/InventoryComponent.cs
+++ b/Uchu.World/Objects/Components/ReplicaComponents/InventoryComponent.cs
@@ -223,8 +223,9 @@ namespace Uchu.World
 
         private static async Task<Lot[]> ParseProxyItemsAsync(Lot item)
         {
+            var componentId = item.GetComponentId(ComponentId.ItemComponent);
             var itemInfo = (await ClientCache.GetTableAsync<ItemComponent>()).FirstOrDefault(
-                i => i.Id == item.GetComponentId(ComponentId.ItemComponent)
+                i => i.Id == componentId
             );
 
             if (itemInfo == default) return new Lot[0];

--- a/Uchu.World/Objects/Components/ReplicaComponents/LuaScriptComponent.cs
+++ b/Uchu.World/Objects/Components/ReplicaComponents/LuaScriptComponent.cs
@@ -3,6 +3,7 @@ using InfectedRose.Lvl;
 using RakDotNet.IO;
 using Uchu.Core;
 using Uchu.Core.Client;
+using Uchu.World.Client;
 
 namespace Uchu.World
 {
@@ -20,11 +21,9 @@ namespace Uchu.World
         {
             Listen(OnStart, () =>
             {
-                using var ctx = new CdClientContext();
-            
                 var scriptId = GameObject.Lot.GetComponentId(ComponentId.ScriptComponent);
 
-                var script = ctx.ScriptComponentTable.FirstOrDefault(s => s.Id == scriptId);
+                var script = ClientCache.GetTable<ScriptComponent>().FirstOrDefault(s => s.Id == scriptId);
 
                 if (script == default)
                 {

--- a/Uchu.World/Objects/Components/ReplicaComponents/MovementAiComponent.cs
+++ b/Uchu.World/Objects/Components/ReplicaComponents/MovementAiComponent.cs
@@ -108,9 +108,10 @@ namespace Uchu.World
                 Listen(GameObject.OnStart, async () =>
                 {
                     if (Zone.NavMeshManager == default || !Zone.NavMeshManager.Enabled) return;
-                    
+
+                    var componentId = GameObject.Lot.GetComponentId(ComponentId.MovementAIComponent);
                     var info = (await ClientCache.GetTableAsync<MovementAIComponent>()).FirstOrDefault(
-                        m => m.Id == GameObject.Lot.GetComponentId(ComponentId.MovementAIComponent)
+                        m => m.Id == componentId
                     );
 
                     if (info == default)

--- a/Uchu.World/Objects/Components/ReplicaComponents/MovementAiComponent.cs
+++ b/Uchu.World/Objects/Components/ReplicaComponents/MovementAiComponent.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore;
 using RakDotNet.IO;
 using Uchu.Core;
 using Uchu.Core.Client;
+using Uchu.World.Client;
 
 namespace Uchu.World
 {
@@ -107,10 +108,8 @@ namespace Uchu.World
                 Listen(GameObject.OnStart, async () =>
                 {
                     if (Zone.NavMeshManager == default || !Zone.NavMeshManager.Enabled) return;
-
-                    await using var ctx = new CdClientContext();
-
-                    var info = await ctx.MovementAIComponentTable.FirstOrDefaultAsync(
+                    
+                    var info = (await ClientCache.GetTableAsync<MovementAIComponent>()).FirstOrDefault(
                         m => m.Id == GameObject.Lot.GetComponentId(ComponentId.MovementAIComponent)
                     );
 

--- a/Uchu.World/Objects/Components/ReplicaComponents/PetComponent.cs
+++ b/Uchu.World/Objects/Components/ReplicaComponents/PetComponent.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using RakDotNet.IO;
 using Uchu.Core;
 using Uchu.Core.Client;
+using Uchu.World.Client;
 
 namespace Uchu.World
 {
@@ -75,11 +76,9 @@ namespace Uchu.World
         {
             if (PetWild)
             {
-                CdClientContext context = new CdClientContext();
-                
                 XmlDocument doc = new XmlDocument();
-                doc.Load(Path.Combine(Zone.UchuServer.Config.ResourcesConfiguration.GameResourceFolder, context
-                    .TamingBuildPuzzlesTable.FirstOrDefault(i => i.NPCLot == GameObject.Lot)
+                doc.Load(Path.Combine(Zone.UchuServer.Config.ResourcesConfiguration.GameResourceFolder,
+                    ClientCache.GetTable<TamingBuildPuzzles>().FirstOrDefault(i => i.NPCLot == GameObject.Lot)
                     .ValidPiecesLXF));
 
                 foreach (XmlNode node in doc.DocumentElement.ChildNodes)

--- a/Uchu.World/Objects/Components/ReplicaComponents/QuickBuildComponent.cs
+++ b/Uchu.World/Objects/Components/ReplicaComponents/QuickBuildComponent.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Numerics;
 using System.Threading.Tasks;
 using System.Timers;
@@ -7,6 +8,7 @@ using Microsoft.EntityFrameworkCore;
 using RakDotNet.IO;
 using Uchu.Core;
 using Uchu.Core.Client;
+using Uchu.World.Client;
 using Uchu.World.Scripting.Native;
 
 namespace Uchu.World
@@ -80,10 +82,8 @@ namespace Uchu.World
                 }
                 
                 Logger.Information($"{GameObject} is a rebuild-able!");
-
-                await using var cdClient = new CdClientContext();
-
-                var clientComponent = await cdClient.RebuildComponentTable.FirstOrDefaultAsync(
+                
+                var clientComponent = (await ClientCache.GetTableAsync<RebuildComponent>()).FirstOrDefault(
                     r => r.Id == GameObject.Lot.GetComponentId(ComponentId.QuickBuildComponent)
                 );
 

--- a/Uchu.World/Objects/Components/ReplicaComponents/QuickBuildComponent.cs
+++ b/Uchu.World/Objects/Components/ReplicaComponents/QuickBuildComponent.cs
@@ -82,9 +82,10 @@ namespace Uchu.World
                 }
                 
                 Logger.Information($"{GameObject} is a rebuild-able!");
-                
+
+                var componentId = GameObject.Lot.GetComponentId(ComponentId.QuickBuildComponent);
                 var clientComponent = (await ClientCache.GetTableAsync<RebuildComponent>()).FirstOrDefault(
-                    r => r.Id == GameObject.Lot.GetComponentId(ComponentId.QuickBuildComponent)
+                    r => r.Id == componentId
                 );
 
                 if (ActivityId == default)

--- a/Uchu.World/Objects/Components/ReplicaComponents/ScriptedActivityComponent.cs
+++ b/Uchu.World/Objects/Components/ReplicaComponents/ScriptedActivityComponent.cs
@@ -7,6 +7,7 @@ using RakDotNet.IO;
 using Uchu.Core;
 using Uchu.Core.Client;
 using Uchu.Core.Resources;
+using Uchu.World.Client;
 
 namespace Uchu.World
 {
@@ -36,15 +37,13 @@ namespace Uchu.World
                 }
 
                 var activityId = (int) id;
-                await using var cdClient = new CdClientContext();
-
-                ActivityInfo = await cdClient.ActivitiesTable.FirstOrDefaultAsync(
+                ActivityInfo = (await ClientCache.GetTableAsync<Activities>()).FirstOrDefault(
                     a => a.ActivityID == activityId
                 );
 
                 if (ActivityInfo == default) return;
                 
-                ActivityInfo = await cdClient.ActivitiesTable.FirstOrDefaultAsync(
+                ActivityInfo = (await ClientCache.GetTableAsync<Activities>()).FirstOrDefault(
                     a => a.ActivityID == activityId
                 );
 
@@ -54,7 +53,7 @@ namespace Uchu.World
                     return;
                 }
 
-                Rewards = cdClient.ActivityRewardsTable.Where(
+                Rewards = ClientCache.GetTable<ActivityRewards>().Where(
                     a => a.ObjectTemplate == activityId
                 ).ToArray();
             });
@@ -62,9 +61,7 @@ namespace Uchu.World
 
         public async Task DropLootAsync(Player lootOwner)
         {
-            await using var cdClient = new CdClientContext();
-            
-            var matrices = cdClient.LootMatrixTable.Where(l =>
+            var matrices = ClientCache.GetTable<Core.Client.LootMatrix>().Where(l =>
                 Rewards.Any(r => r.LootMatrixIndex == l.LootMatrixIndex)
             ).ToArray();
 
@@ -72,7 +69,7 @@ namespace Uchu.World
             {
                 var count = _random.Next(matrix.MinToDrop ?? 0, matrix.MaxToDrop ?? 0);
 
-                var items = cdClient.LootTableTable.Where(t => t.LootTableIndex == matrix.LootTableIndex).ToList();
+                var items = ClientCache.GetTable<LootTable>().Where(t => t.LootTableIndex == matrix.LootTableIndex).ToList();
                 
                 for (var i = 0; i < count; i++)
                 {
@@ -107,7 +104,7 @@ namespace Uchu.World
 
             foreach (var reward in Rewards)
             {
-                var currencies = cdClient.CurrencyTableTable.Where(c => 
+                var currencies = ClientCache.GetTable<CurrencyTable>().Where(c => 
                     c.CurrencyIndex == reward.CurrencyIndex
                 );
 

--- a/Uchu.World/Objects/Components/ReplicaComponents/SkillComponent.cs
+++ b/Uchu.World/Objects/Components/ReplicaComponents/SkillComponent.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore;
 using RakDotNet.IO;
 using Uchu.Core;
 using Uchu.Core.Client;
+using Uchu.World.Client;
 using Uchu.World.Systems.Behaviors;
 
 namespace Uchu.World
@@ -41,11 +42,9 @@ namespace Uchu.World
             
             Listen(OnStart, async () =>
             {
-                await using var cdClient = new CdClientContext();
-
-                var skills = await cdClient.ObjectSkillsTable.Where(
+                var skills = (await ClientCache.GetTableAsync<ObjectSkills>()).Where(
                     s => s.ObjectTemplate == GameObject.Lot
-                ).ToArrayAsync();
+                ).ToArray();
 
                 DefaultSkillSet = skills
                     .Where(s => s.SkillID != default)
@@ -98,9 +97,7 @@ namespace Uchu.World
         {
             if (item == default) return;
             
-            await using var ctx = new CdClientContext();
-
-            var itemInfo = await ctx.ItemComponentTable.FirstOrDefaultAsync(
+            var itemInfo = (await ClientCache.GetTableAsync<ItemComponent>()).FirstOrDefault(
                 i => i.Id == item.GetComponentId(ComponentId.ItemComponent)
             );
             
@@ -118,10 +115,7 @@ namespace Uchu.World
         public async Task DismountItemAsync(Lot item)
         {
             if (item == default) return;
-
-            await using var ctx = new CdClientContext();
-
-            var itemInfo = await ctx.ItemComponentTable.FirstOrDefaultAsync(
+            var itemInfo = (await ClientCache.GetTableAsync<ItemComponent>()).FirstOrDefault(
                 i => i.Id == item.GetComponentId(ComponentId.ItemComponent)
             );
             
@@ -138,9 +132,7 @@ namespace Uchu.World
         {
             if (item == default) return;
             
-            await using var ctx = new CdClientContext();
-
-            var itemInfo = await ctx.ItemComponentTable.FirstOrDefaultAsync(
+            var itemInfo = (await ClientCache.GetTableAsync<ItemComponent>()).FirstOrDefault(
                 i => i.Id == item.GetComponentId(ComponentId.ItemComponent)
             );
             

--- a/Uchu.World/Objects/Components/ReplicaComponents/SkillComponent.cs
+++ b/Uchu.World/Objects/Components/ReplicaComponents/SkillComponent.cs
@@ -97,8 +97,9 @@ namespace Uchu.World
         {
             if (item == default) return;
             
+            var targetId = item.GetComponentId(ComponentId.ItemComponent);
             var itemInfo = (await ClientCache.GetTableAsync<ItemComponent>()).FirstOrDefault(
-                i => i.Id == item.GetComponentId(ComponentId.ItemComponent)
+                i => i.Id == targetId
             );
             
             if (itemInfo == default) return;
@@ -115,8 +116,9 @@ namespace Uchu.World
         public async Task DismountItemAsync(Lot item)
         {
             if (item == default) return;
+            var componentId = item.GetComponentId(ComponentId.ItemComponent);
             var itemInfo = (await ClientCache.GetTableAsync<ItemComponent>()).FirstOrDefault(
-                i => i.Id == item.GetComponentId(ComponentId.ItemComponent)
+                i => i.Id == componentId
             );
             
             if (itemInfo == default) return;
@@ -132,8 +134,9 @@ namespace Uchu.World
         {
             if (item == default) return;
             
+            var componentId = item.GetComponentId(ComponentId.ItemComponent);
             var itemInfo = (await ClientCache.GetTableAsync<ItemComponent>()).FirstOrDefault(
-                i => i.Id == item.GetComponentId(ComponentId.ItemComponent)
+                i => i.Id == componentId
             );
             
             if (itemInfo == default) return;

--- a/Uchu.World/Objects/Components/ReplicaComponents/VendorComponent.cs
+++ b/Uchu.World/Objects/Components/ReplicaComponents/VendorComponent.cs
@@ -100,8 +100,9 @@ namespace Uchu.World
 
         public async Task Buy(Lot lot, uint count, Player player)
         {
+            var componentId = lot.GetComponentId(ComponentId.ItemComponent);
             var itemComponent = (await ClientCache.GetTableAsync<ItemComponent>()).First(
-                i => i.Id == lot.GetComponentId(ComponentId.ItemComponent)
+                i => i.Id == componentId
             );
             
             if (count == default || itemComponent.BaseValue <= 0) return;

--- a/Uchu.World/Objects/Components/ReplicaComponents/VendorComponent.cs
+++ b/Uchu.World/Objects/Components/ReplicaComponents/VendorComponent.cs
@@ -7,6 +7,7 @@ using Microsoft.EntityFrameworkCore;
 using RakDotNet.IO;
 using Uchu.Core;
 using Uchu.Core.Client;
+using Uchu.World.Client;
 
 namespace Uchu.World
 {
@@ -71,18 +72,15 @@ namespace Uchu.World
         {
             var componentId = GameObject.Lot.GetComponentId(ComponentId.VendorComponent);
 
-            await using var cdClient = new CdClientContext();
+            var vendorComponent = (await ClientCache.GetTableAsync<Core.Client.VendorComponent>()).First(c => c.Id == componentId);
 
-            var vendorComponent = await cdClient.VendorComponentTable.FirstAsync(c => c.Id == componentId);
-
-            var matrices =
-                cdClient.LootMatrixTable.Where(l => l.LootMatrixIndex == vendorComponent.LootMatrixIndex);
+            var matrices = ClientCache.GetTable<Core.Client.LootMatrix>().Where(l => l.LootMatrixIndex == vendorComponent.LootMatrixIndex);
 
             var shopItems = new List<ShopEntry>();
 
             foreach (var matrix in matrices)
             {
-                shopItems.AddRange(cdClient.LootTableTable.Where(
+                shopItems.AddRange(ClientCache.GetTable<LootTable>().Where(
                     l => l.LootTableIndex == matrix.LootTableIndex
                 ).ToArray().Select(lootTable =>
                 {
@@ -102,9 +100,7 @@ namespace Uchu.World
 
         public async Task Buy(Lot lot, uint count, Player player)
         {
-            await using var ctx = new CdClientContext();
-
-            var itemComponent = await ctx.ItemComponentTable.FirstAsync(
+            var itemComponent = (await ClientCache.GetTableAsync<ItemComponent>()).First(
                 i => i.Id == lot.GetComponentId(ComponentId.ItemComponent)
             );
             

--- a/Uchu.World/Objects/Components/Server/LootContainerComponent.cs
+++ b/Uchu.World/Objects/Components/Server/LootContainerComponent.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Uchu.Core;
 using Uchu.Core.Client;
+using Uchu.World.Client;
 
 namespace Uchu.World
 {
@@ -134,17 +135,15 @@ namespace Uchu.World
 
         private async Task QueryLootMatrixAsync()
         {
-            await using var ctx = new CdClientContext();
-
-            var matrices = await ctx.LootMatrixTable.Where(
+            var matrices = (await ClientCache.GetTableAsync<Core.Client.LootMatrix>()).Where(
                 m => m.LootMatrixIndex == LootIndex
-            ).ToArrayAsync();
+            ).ToArray();
 
             foreach (var matrix in matrices)
             {
-                var tables = await ctx.LootTableTable.Where(
+                var tables = (await ClientCache.GetTableAsync<LootTable>()).Where(
                     t => t.LootTableIndex == matrix.LootTableIndex
-                ).ToArrayAsync();
+                ).ToArray();
 
                 var items = tables.Select(t => new LootMatrixEntry
                 {
@@ -169,11 +168,9 @@ namespace Uchu.World
 
         private async Task QueryCurrencyMatrixAsync()
         {
-            await using var ctx = new CdClientContext();
-
-            var matrices = await ctx.CurrencyTableTable.Where(
+            var matrices = (await ClientCache.GetTableAsync<CurrencyTable>()).Where(
                 c => c.CurrencyIndex == CurrencyIndex
-            ).ToArrayAsync();
+            ).ToArray();
 
             foreach (var matrix in matrices)
             {
@@ -190,13 +187,11 @@ namespace Uchu.World
 
         private async Task FindMatrixIndicesAsync()
         {
-            await using var ctx = new CdClientContext();
-
             var destructible = GameObject.Lot.GetComponentId(ComponentId.DestructibleComponent);
 
             if (destructible != default)
             {
-                var component = await ctx.DestructibleComponentTable.FirstOrDefaultAsync(
+                var component = (await ClientCache.GetTableAsync<Core.Client.DestructibleComponent>()).FirstOrDefault(
                     c => c.Id == destructible
                 );
 
@@ -213,7 +208,7 @@ namespace Uchu.World
 
             if (package != default)
             {
-                var component = await ctx.PackageComponentTable.FirstOrDefaultAsync(
+                var component = (await ClientCache.GetTableAsync<PackageComponent>()).FirstOrDefault(
                     c => c.Id == package
                 );
 

--- a/Uchu.World/Objects/Components/Server/MissionGiverComponent.cs
+++ b/Uchu.World/Objects/Components/Server/MissionGiverComponent.cs
@@ -40,33 +40,30 @@ namespace Uchu.World
         /// </summary>
         private void CollectMissions()
         {
-            using (var ctx = new CdClientContext())
+            var components = ClientCache.GetTable<ComponentsRegistry>().Where(
+                c => c.Id == GameObject.Lot && c.Componenttype == (int) ComponentId.MissionNPCComponent
+            ).ToArray();
+
+            var missionComponents = components.SelectMany(
+                component => ClientCache.GetTable<MissionNPCComponent>().Where(m => m.Id == component.Componentid)
+            ).ToArray();
+
+            var missions = new List<(Missions, MissionNPCComponent)>();
+            
+            foreach (var npcComponent in missionComponents)
             {
-                var components = ctx.ComponentsRegistryTable.Where(
-                    c => c.Id == GameObject.Lot && c.Componenttype == (int) ComponentId.MissionNPCComponent
-                ).ToArray();
+                var quest = ClientCache.GetTable<Missions>().FirstOrDefault(m => m.Id == npcComponent.MissionID);
 
-                var missionComponents = components.SelectMany(
-                    component => ctx.MissionNPCComponentTable.Where(m => m.Id == component.Componentid)
-                ).ToArray();
-
-                var missions = new List<(Missions, MissionNPCComponent)>();
-                
-                foreach (var npcComponent in missionComponents)
+                if (quest == default)
                 {
-                    var quest = ctx.MissionsTable.FirstOrDefault(m => m.Id == npcComponent.MissionID);
-
-                    if (quest == default)
-                    {
-                        Logger.Warning($"{GameObject} has a Mission NPC Component with no corresponding quest: \"[{GameObject.Lot}] {GameObject.Name}\" [{npcComponent.Id}] {npcComponent.MissionID}");
-                        continue;
-                    }
-                    
-                    missions.Add((quest, npcComponent));
+                    Logger.Warning($"{GameObject} has a Mission NPC Component with no corresponding quest: \"[{GameObject.Lot}] {GameObject.Name}\" [{npcComponent.Id}] {npcComponent.MissionID}");
+                    continue;
                 }
-
-                Missions = missions.ToArray();
+                
+                missions.Add((quest, npcComponent));
             }
+
+            Missions = missions.ToArray();
 
             Logger.Information(
                 $"{GameObject} is a quest give with: {string.Join(" ", Missions.Select(s => s.Item1.Id))}"

--- a/Uchu.World/Objects/GameObjects/GameObject.cs
+++ b/Uchu.World/Objects/GameObjects/GameObject.cs
@@ -7,6 +7,7 @@ using InfectedRose.Lvl;
 using RakDotNet.IO;
 using Uchu.Core;
 using Uchu.Core.Client;
+using Uchu.World.Client;
 
 namespace Uchu.World
 {
@@ -323,11 +324,8 @@ namespace Uchu.World
 
                 instance.Name = name;
 
-                using (var cdClient = new CdClientContext())
-                {
-                    var obj = cdClient.ObjectsTable.FirstOrDefault(o => o.Id == lot);
-                    instance.ClientName = obj?.Name;
-                }
+                var obj = ClientCache.GetTable<Objects>().FirstOrDefault(o => o.Id == lot);
+                instance.ClientName = obj?.Name;
 
                 instance.Spawner = spawner;
 
@@ -415,8 +413,6 @@ namespace Uchu.World
 
             if (levelObject.LegoInfo.TryGetValue("spawntemplate", out _))
                 return InstancingUtilities.Spawner(levelObject, parent);
-
-            using var ctx = new CdClientContext();
             
             var name = levelObject.LegoInfo.TryGetValue("npcName", out var npcName) ? (string) npcName : "";
 
@@ -446,7 +442,7 @@ namespace Uchu.World
             // Collect all the components on this object
             //
 
-            var registryComponents = ctx.ComponentsRegistryTable.Where(
+            var registryComponents = ClientCache.GetTable<ComponentsRegistry>().Where(
                 r => r.Id == levelObject.Lot
             ).ToArray();
 

--- a/Uchu.World/Objects/GameObjects/Item.cs
+++ b/Uchu.World/Objects/GameObjects/Item.cs
@@ -5,6 +5,7 @@ using InfectedRose.Lvl;
 using Microsoft.EntityFrameworkCore;
 using Uchu.Core;
 using Uchu.Core.Client;
+using Uchu.World.Client;
 
 namespace Uchu.World
 {
@@ -22,10 +23,8 @@ namespace Uchu.World
             Listen(OnStart, () =>
             {
                 IsPackage = Lot.GetComponentId(ComponentId.PackageComponent) != default;
-                
-                using var cdClient = new CdClientContext();
 
-                var skills = cdClient.ObjectSkillsTable.Where(
+                var skills = ClientCache.GetTable<ObjectSkills>().Where(
                     s => s.ObjectTemplate == Lot
                 ).ToArray();
 
@@ -41,11 +40,9 @@ namespace Uchu.World
         {
             get
             {
-                using var cdClient = new CdClientContext();
-
                 var id = Lot.GetComponentId(ComponentId.ItemComponent);
 
-                return cdClient.ItemComponentTable.FirstOrDefault(c => c.Id == id);
+                return ClientCache.GetTable<ItemComponent>().FirstOrDefault(c => c.Id == id);
             }
         }
         
@@ -186,7 +183,6 @@ namespace Uchu.World
 
         public static Item Instantiate(long itemId, Inventory inventory)
         {
-            using var cdClient = new CdClientContext();
             using var ctx = new UchuContext();
             
             var item = ctx.InventoryItems.FirstOrDefault(
@@ -199,7 +195,7 @@ namespace Uchu.World
                 return null;
             }
 
-            var cdClientObject = cdClient.ObjectsTable.FirstOrDefault(
+            var cdClientObject = ClientCache.GetTable<Objects>().FirstOrDefault(
                 o => o.Id == item.Lot
             );
 
@@ -241,14 +237,13 @@ namespace Uchu.World
 
         public static Item Instantiate(Lot lot, Inventory inventory, uint count, uint slot, LegoDataDictionary extraInfo = default)
         {
-            using var cdClient = new CdClientContext();
             using var ctx = new UchuContext();
             
-            var cdClientObject = cdClient.ObjectsTable.FirstOrDefault(
+            var cdClientObject = ClientCache.GetTable<Objects>().FirstOrDefault(
                 o => o.Id == lot
             );
 
-            var itemRegistryEntry = cdClient.ComponentsRegistryTable.FirstOrDefault(
+            var itemRegistryEntry = ClientCache.GetTable<ComponentsRegistry>().FirstOrDefault(
                 r => r.Id == lot && r.Componenttype == 11
             );
 
@@ -265,7 +260,7 @@ namespace Uchu.World
 
             instance.Settings = extraInfo ?? new LegoDataDictionary();
 
-            var itemComponent = cdClient.ItemComponentTable.First(
+            var itemComponent = ClientCache.GetTable<ItemComponent>().First(
                 i => i.Id == itemRegistryEntry.Componentid
             );
 

--- a/Uchu.World/Objects/Perspective/Filters/RenderDistanceFilter.cs
+++ b/Uchu.World/Objects/Perspective/Filters/RenderDistanceFilter.cs
@@ -2,6 +2,7 @@ using System.Linq;
 using System.Numerics;
 using System.Threading.Tasks;
 using Uchu.Core.Client;
+using Uchu.World.Client;
 
 namespace Uchu.World.Filters
 {
@@ -18,10 +19,7 @@ namespace Uchu.World.Filters
         public void Initialize(Player player)
         {
             Player = player;
-            
-            using var cdClient = new CdClientContext();
-
-            var zone = cdClient.ZoneTableTable.FirstOrDefault(z => z.ZoneID == (int) Player.Zone.ZoneId);
+            var zone = ClientCache.GetTable<ZoneTable>().FirstOrDefault(z => z.ZoneID == (int) Player.Zone.ZoneId);
 
             Distance = zone?.Ghostdistance ?? 500;
         }

--- a/Uchu.World/Objects/Zone.cs
+++ b/Uchu.World/Objects/Zone.cs
@@ -13,6 +13,7 @@ using InfectedRose.Utilities;
 using RakDotNet;
 using RakDotNet.IO;
 using Uchu.Core;
+using Uchu.Core.Client;
 using Uchu.Physics;
 using Uchu.Python;
 using Uchu.World.Client;
@@ -197,9 +198,7 @@ namespace Uchu.World
                 
             }
 
-            using var ctx = new Uchu.Core.Client.CdClientContext();
-
-            int? ZoneControlLot = ctx.ZoneTableTable.FirstOrDefault(o => o.ZoneID == this.ZoneId.Id).ZoneControlTemplate;
+            int? ZoneControlLot = ClientCache.GetTable<ZoneTable>().FirstOrDefault(o => o.ZoneID == this.ZoneId.Id).ZoneControlTemplate;
 
             int Lot = ZoneControlLot ??= 2365;
 

--- a/Uchu.World/Services/Requirements.cs
+++ b/Uchu.World/Services/Requirements.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Uchu.Core;
 using Uchu.Core.Client;
+using Uchu.World.Client;
 
 namespace Uchu.World.Services
 {
@@ -106,9 +107,7 @@ namespace Uchu.World.Services
         
         public static async Task<bool> CheckPreconditionAsync(int id, Player player)
         {
-            await using var cdClient = new CdClientContext();
-
-            var precondition = await cdClient.PreconditionsTable.FirstOrDefaultAsync(
+            var precondition = (await ClientCache.GetTableAsync<Preconditions>()).FirstOrDefault(
                 p => p.Id == id
             );
 

--- a/Uchu.World/Structs/Lot.cs
+++ b/Uchu.World/Structs/Lot.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using Uchu.Core.Client;
+using Uchu.World.Client;
 
 namespace Uchu.World
 {
@@ -51,9 +52,8 @@ namespace Uchu.World
         {
             get
             {
-                using var cdClient = new CdClientContext();
                 var id = Id;
-                return cdClient.ObjectsTable.FirstOrDefault(o => o.Id == id);
+                return ClientCache.GetTable<Objects>().FirstOrDefault(o => o.Id == id);
             }
         }
 
@@ -65,8 +65,7 @@ namespace Uchu.World
         public int GetComponentId(int componentType)
         {
             var id = Id;
-            using var cdClient = new CdClientContext();
-            var itemRegistryEntry = cdClient.ComponentsRegistryTable.FirstOrDefault(
+            var itemRegistryEntry = ClientCache.GetTable<ComponentsRegistry>().FirstOrDefault(
                 r => r.Id == id && r.Componenttype == componentType
             );
 
@@ -81,10 +80,7 @@ namespace Uchu.World
         public int[] GetComponentIds(int componentType)
         {
             var id = Id;
-
-            using var cdClient = new CdClientContext();
-
-            var itemRegistryEntry = cdClient.ComponentsRegistryTable.Where(
+            var itemRegistryEntry = ClientCache.GetTable<ComponentsRegistry>().Where(
                 r => r.Id == id && r.Componenttype == componentType
             );
 

--- a/Uchu.World/Systems/Behaviors/BehaviorBase.cs
+++ b/Uchu.World/Systems/Behaviors/BehaviorBase.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore;
 using RakDotNet.IO;
 using Uchu.Core;
 using Uchu.Core.Client;
+using Uchu.World.Client;
 using Uchu.World.Scripting.Native;
 
 namespace Uchu.World.Systems.Behaviors
@@ -235,10 +236,8 @@ namespace Uchu.World.Systems.Behaviors
         {
             var cachedBehavior = Cache.ToArray().FirstOrDefault(c => c.BehaviorId == behaviorId);
             if (cachedBehavior != default) return cachedBehavior;
-            
-            await using var ctx = new CdClientContext();
 
-            var behavior = await ctx.BehaviorTemplateTable.FirstOrDefaultAsync(
+            var behavior = (await ClientCache.GetTableAsync<BehaviorTemplate>()).FirstOrDefault(
                 t => t.BehaviorID == behaviorId
             );
             
@@ -273,8 +272,7 @@ namespace Uchu.World.Systems.Behaviors
         /// <returns>The behavior parameter from the database</returns>
         protected async Task<BehaviorParameter> GetParameter(string name)
         {
-            await using var cdClient = new CdClientContext();
-            return await cdClient.BehaviorParameterTable.FirstOrDefaultAsync(p =>
+            return (await ClientCache.GetTableAsync<BehaviorParameter>()).FirstOrDefault(p =>
                 p.BehaviorID == BehaviorId && p.ParameterID == name
             );
         }
@@ -301,8 +299,7 @@ namespace Uchu.World.Systems.Behaviors
         /// </summary>
         protected BehaviorParameter[] GetParameters()
         {
-            using var cdClient = new CdClientContext();
-            return cdClient.BehaviorParameterTable.Where(p =>
+            return ClientCache.GetTable<BehaviorParameter>().Where(p =>
                 p.BehaviorID == BehaviorId
             ).ToArray();
         }
@@ -313,8 +310,7 @@ namespace Uchu.World.Systems.Behaviors
         /// <returns>The behavior template associated with this behavior</returns>
         public async Task<BehaviorTemplate> GetTemplate()
         {
-            await using var cdClient = new CdClientContext();
-            return await cdClient.BehaviorTemplateTable.FirstOrDefaultAsync(p =>
+            return (await ClientCache.GetTableAsync<BehaviorTemplate>()).FirstOrDefault(p =>
                 p.BehaviorID == BehaviorId
             );
         }

--- a/Uchu.World/Systems/Behaviors/BehaviorExecutionParameters.cs
+++ b/Uchu.World/Systems/Behaviors/BehaviorExecutionParameters.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Linq;
 using System.Threading;
 using Microsoft.EntityFrameworkCore;
 using RakDotNet.IO;
 using Uchu.Core.Client;
+using Uchu.World.Client;
 using Uchu.World.Scripting.Native;
 
 namespace Uchu.World.Systems.Behaviors
@@ -102,10 +104,8 @@ namespace Uchu.World.Systems.Behaviors
         public async void PlayFX(string type, int effectId, int time = 1000, GameObject target = default)
         {
             target ??= BranchContext.Target;
-            
-            await using var ctx = new CdClientContext();
 
-            var fx = await ctx.BehaviorEffectTable.FirstOrDefaultAsync(
+            var fx = (await ClientCache.GetTableAsync<BehaviorEffect>()).FirstOrDefault(
                 e => e.EffectType == type && e.EffectID == effectId
             );
             

--- a/Uchu.World/Systems/Behaviors/BehaviorTree.cs
+++ b/Uchu.World/Systems/Behaviors/BehaviorTree.cs
@@ -222,8 +222,6 @@ namespace Uchu.World.Systems.Behaviors
         /// </summary>
         private async Task BuildAsync()
         {
-            await using var ctx = new CdClientContext();
-
             // Build the base behavior for each requested skill
             foreach (var skill in BehaviorIds)
             {

--- a/Uchu.World/Systems/Behaviors/BehaviorTree.cs
+++ b/Uchu.World/Systems/Behaviors/BehaviorTree.cs
@@ -5,9 +5,11 @@ using System.Linq;
 using System.Numerics;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Scripting.Hosting.Shell;
 using RakDotNet.IO;
 using Uchu.Core;
 using Uchu.Core.Client;
+using Uchu.World.Client;
 
 namespace Uchu.World.Systems.Behaviors
 {
@@ -129,11 +131,8 @@ namespace Uchu.World.Systems.Behaviors
         public static async Task<BehaviorTree> FromLotAsync(Lot lot)
         {
             var tree = new BehaviorTree();
-            
-            // TODO: Cache this. NPCs always use the same lot, no reason to look this up each time.
-            await using var cdClient = new CdClientContext();
 
-            var objectSkills = cdClient.ObjectSkillsTable.Where(i =>
+            var objectSkills = (await ClientCache.GetTableAsync<ObjectSkills>()).Where(i =>
                 i.ObjectTemplate == lot
             ).ToArray();
 
@@ -142,7 +141,7 @@ namespace Uchu.World.Systems.Behaviors
             for (var index = 0; index < objectSkills.Length; index++)
             {
                 var objectSkill = objectSkills[index];
-                var behavior = cdClient.SkillBehaviorTable.FirstOrDefault(b => b.SkillID == objectSkill.SkillID);
+                var behavior = (await ClientCache.GetTableAsync<SkillBehavior>()).FirstOrDefault(b => b.SkillID == objectSkill.SkillID);
 
                 if (behavior == default)
                 {
@@ -203,8 +202,7 @@ namespace Uchu.World.Systems.Behaviors
         /// <returns>The skill behavior if it existed, <c>default</c> otherwise</returns>
         private static async Task<SkillBehavior> BaseBehaviorForSkill(int skillId)
         {
-            await using var clientContext = new CdClientContext();
-            var skillBehavior = clientContext.SkillBehaviorTable.FirstOrDefault(b => b.SkillID == skillId);
+            var skillBehavior = (await ClientCache.GetTableAsync<SkillBehavior>()).FirstOrDefault(b => b.SkillID == skillId);
             
             if (skillBehavior == default)
             {
@@ -235,7 +233,7 @@ namespace Uchu.World.Systems.Behaviors
                 // If the behavior can't be found in the cache, build it from scratch using its template
                 if (root == default)
                 {
-                    root = await BehaviorFromInfo(ctx, skill);
+                    root = await BehaviorFromInfo(skill);
                     if (root == null)
                     {
                         continue;
@@ -272,9 +270,9 @@ namespace Uchu.World.Systems.Behaviors
         /// <param name="context">Reusable context to query from</param>
         /// <param name="info">The behavior info to get the skill from</param>
         /// <returns>The instantiated behavior base if succeeded, <c>null</c> otherwise</returns>
-        private static async Task<BehaviorBase> BehaviorFromInfo(CdClientContext context, BehaviorInfo info)
+        private static async Task<BehaviorBase> BehaviorFromInfo(BehaviorInfo info)
         {
-            var behavior = await context.BehaviorTemplateTable.FirstOrDefaultAsync(
+            var behavior = (await ClientCache.GetTableAsync<BehaviorTemplate>()).FirstOrDefault(
                 t => t.BehaviorID == info.BaseBehavior
             );
 


### PR DESCRIPTION
*Closes https://github.com/UchuServer/Uchu/issues/117*
*Re-do of https://github.com/UchuServer/Uchu/pull/174*
*Includes https://github.com/UchuServer/Uchu/pull/175*

This pull request is a redo of the improving world load time enhancement, which had a very high memory usage. This version is able to get to <15 seconds from world startup to the player loading like the last pull request, but results in the world loading in at <160 MBs instead of ~280 MBs. This is done by briefly caching tables for a couple of seconds when read so that a sudden amount of reads doesn't constantly re-read the database while also not causing the memory hit of keeping all the tables in memory as structs.

Last time, it was found that using caching for some components would result in load times in the minutes. However, I found that there is an inefficiency with some of the table reads regarding [`Lot.GetComponentId`](https://github.com/UchuServer/Uchu/blob/dev/Uchu.World/Structs/Lot.cs#L65). There were some cases that would call it in a Linq statement, like the [`DestroyableComponent`](https://github.com/UchuServer/Uchu/blob/e381704495e7f04adb74710e70fbfe8ca0ee7af6/Uchu.World/Objects/Components/DestroyableComponent.cs#L220), which causes a database table read with each cycle instead of once before the Linq statement, [like the new code](https://github.com/UchuServer/Uchu/blob/54ffbb5615cb7e29a60481bdc9b82a4036b81e1d/Uchu.World/Objects/Components/DestroyableComponent.cs#L218). Table caching with the new method brought my Avant Gardens load time from >50 seconds to <30, and this change brought it from <30 to <15.