### PR TITLE
Implement Quick Builds with Smashables

### DIFF
--- a/Uchu.World/Objects/Components/ReplicaComponents/DestructibleComponent.cs
+++ b/Uchu.World/Objects/Components/ReplicaComponents/DestructibleComponent.cs
@@ -145,7 +145,10 @@ namespace Uchu.World
                 GameObject.Layer -= StandardLayer.Smashable;
                 GameObject.Layer += StandardLayer.Hidden;
 
-                InitializeRespawn();
+                if (GameObject.Spawner == default)
+                {
+                    InitializeRespawn();
+                }
                 
                 if (owner != null)
                 {

--- a/Uchu.World/Objects/Components/ReplicaComponents/QuickBuildComponent.cs
+++ b/Uchu.World/Objects/Components/ReplicaComponents/QuickBuildComponent.cs
@@ -33,10 +33,7 @@ namespace Uchu.World
 
         public RebuildState State
         {
-            get
-            {
-                return _state;
-            }
+            get => _state;
             set
             {
                 _state = value;
@@ -104,8 +101,11 @@ namespace Uchu.World
                     return;
                 }
                 
-                _completeTime = clientComponent.Completetime ?? 0;
                 _imaginationCost = clientComponent.Takeimagination ?? 0;
+                
+                // If no completion time is provided we assume 1 second per imagination spent
+                _completeTime = clientComponent.Completetime ?? _imaginationCost;
+                
                 _timeToSmash = clientComponent.Timebeforesmash ?? 0;
                 _resetTime = clientComponent.Resettime ?? 0;
 
@@ -303,7 +303,6 @@ namespace Uchu.World
             if (_timer == default)
             {
                 _timer = new PauseTimer(_completeTime * 1000);
-
                 _timer.Elapsed += (sender, args) => {  };
             }
             else
@@ -332,7 +331,6 @@ namespace Uchu.World
                 if (_taken != _imaginationCost)
                 {
                     _taken++;
-
                     playerStats.Imagination--;
 
                     GameObject.Serialize(GameObject);

--- a/Uchu.World/Objects/Components/ReplicaComponents/QuickBuildComponent.cs
+++ b/Uchu.World/Objects/Components/ReplicaComponents/QuickBuildComponent.cs
@@ -205,6 +205,34 @@ namespace Uchu.World
         private void Hide()
         {
             Enabled = false;
+            if (State == RebuildState.Building)
+            {
+                Zone.BroadcastMessage(new RebuildNotifyStateMessage
+                {
+                    Associate = GameObject,
+                    CurrentState = State,
+                    NewState = RebuildState.Resetting,
+                    Player = (Player)Participants.ElementAt(0)
+                });
+            }
+            Zone.BroadcastMessage(new DieMessage {
+                Associate = GameObject,
+                SpawnLoot = true,
+                KillType = 0, // violent
+                Killer = GameObject.InvalidObject
+            });
+            Zone.BroadcastMessage(new DieMessage {
+                Associate = Activator,
+                SpawnLoot = true,
+                KillType = 0, // violent
+                Killer = GameObject.InvalidObject
+            });
+            Zone.BroadcastMessage(new StopFXEffectMessage
+            {
+                Associate = GameObject,
+                KillImmediate = true,
+                Name = "BrickFadeUpVisCompleteEffect"
+            });
             GameObject.Layer = StandardLayer.Hidden;
             Activator.Layer = StandardLayer.Hidden;
         }
@@ -215,6 +243,15 @@ namespace Uchu.World
         private void Show()
         {
             Enabled = true;
+            Zone.BroadcastMessage(new ResurrectMessage
+            {
+                Associate = GameObject,
+                ResurrectImminently = true
+            });
+            Zone.BroadcastMessage(new ResurrectMessage {
+                Associate = Activator,
+                ResurrectImminently = true
+            });
             GameObject.Layer = StandardLayer.Default;
             Activator.Layer = StandardLayer.Default;
         }

--- a/Uchu.World/Objects/Components/ReplicaComponents/QuickBuildComponent.cs
+++ b/Uchu.World/Objects/Components/ReplicaComponents/QuickBuildComponent.cs
@@ -449,10 +449,13 @@ namespace Uchu.World
 
             if (LinkedSpawner != default)
             {
-                Enabled = false;
                 GameObject.Layer = StandardLayer.Hidden;
                 Activator.Layer = StandardLayer.Hidden;
-                LinkedSpawner.Spawn();
+                if (Enabled)
+                {
+                    LinkedSpawner.Spawn();
+                }
+                Enabled = false;
             }
         }
 
@@ -493,7 +496,7 @@ namespace Uchu.World
 
             timer.Elapsed += (sender,args) =>
             {
-                if (State == RebuildState.Open)
+                if (State == RebuildState.Open && Enabled)
                 {
                     Enabled = false;
                     GameObject.Layer = StandardLayer.Hidden;

--- a/Uchu.World/Objects/Components/ReplicaComponents/QuickBuildComponent.cs
+++ b/Uchu.World/Objects/Components/ReplicaComponents/QuickBuildComponent.cs
@@ -448,6 +448,14 @@ namespace Uchu.World
             GameObject.Serialize(GameObject);
 
             OpenBuild(player);
+
+            if (LinkedSpawner != default)
+            {
+                Enabled = false;
+                GameObject.Layer = StandardLayer.Hidden;
+                Activator.Layer = StandardLayer.Hidden;
+                LinkedSpawner.Spawn();
+            }
         }
 
         public void OpenBuild(Player player)
@@ -471,6 +479,32 @@ namespace Uchu.World
             State = RebuildState.Open;
 
             GameObject.Serialize(GameObject);
+        }
+        
+        public void EnableBuildFromSpawner()
+        {
+            Enabled = true;
+            GameObject.Layer = StandardLayer.Default;
+            Activator.Layer = StandardLayer.Default;
+            
+            var timer = new Timer
+            {
+                AutoReset = false,
+                Interval = _resetTime * 1000
+            };
+
+            timer.Elapsed += (sender,args) =>
+            {
+                if (State == RebuildState.Open)
+                {
+                    Enabled = false;
+                    GameObject.Layer = StandardLayer.Hidden;
+                    Activator.Layer = StandardLayer.Hidden;
+                    LinkedSpawner.Spawn();
+                }
+            };
+            
+            Task.Run(timer.Start);
         }
     }
 }

--- a/Uchu.World/Objects/Components/ReplicaComponents/QuickBuildComponent.cs
+++ b/Uchu.World/Objects/Components/ReplicaComponents/QuickBuildComponent.cs
@@ -411,15 +411,13 @@ namespace Uchu.World
             });
 
             /*
-             * Reset this quickbuild after three times its completion time.
-             * TODO: Change this to something more correct.
+             * Reset this quickbuild after its smash time.
              */
             var timer = new Timer
             {
                 AutoReset = false,
-                Interval = _resetTime * 1000
+                Interval = _timeToSmash * 1000
             };
-
             timer.Elapsed += (sender, args) => { ResetBuild(player); };
 
             Task.Run(timer.Start);

--- a/Uchu.World/Objects/Components/Server/SpawnerComponent.cs
+++ b/Uchu.World/Objects/Components/Server/SpawnerComponent.cs
@@ -28,12 +28,12 @@ namespace Uchu.World
         /// <summary>
         /// Event that's called after a game object is smashed and the spawner is waiting to respawn the game object
         /// </summary>
-        public Event OnRespawnInitiated { get; }
+        public Event<Player> OnRespawnInitiated { get; }
         
         /// <summary>
         /// Event that's fired after a game object is smashed and the respawn time has passed
         /// </summary>
-        public Event OnRespawnCompleted { get; }
+        public Event<Player> OnRespawnTimeCompleted { get; }
 
         public LegoDataDictionary Settings { get; set; }
 
@@ -42,8 +42,8 @@ namespace Uchu.World
             _random = new Random();
             SpawnLocations = new List<SpawnLocation>();
             ActiveSpawns = new List<GameObject>();
-            OnRespawnInitiated = new Event();
-            OnRespawnCompleted = new Event();
+            OnRespawnInitiated = new Event<Player>();
+            OnRespawnTimeCompleted = new Event<Player>();
             
             Listen(OnStart, () =>
             {
@@ -70,7 +70,7 @@ namespace Uchu.World
             Listen(OnDestroyed, () =>
             {
                 OnRespawnInitiated.Clear();
-                OnRespawnCompleted.Clear();
+                OnRespawnTimeCompleted.Clear();
             });
         }
 
@@ -139,11 +139,11 @@ namespace Uchu.World
                 {
                     Destroy(obj);
 
-                    await OnRespawnInitiated.InvokeAsync();
+                    await OnRespawnInitiated.InvokeAsync(lootOwner);
                     await Task.Delay(RespawnTime);
+                    await OnRespawnTimeCompleted.InvokeAsync(lootOwner);
                     
                     Spawn();
-                    await OnRespawnCompleted.InvokeAsync();
                 });
             }
 

--- a/Uchu.World/Objects/Components/Server/SpawnerComponent.cs
+++ b/Uchu.World/Objects/Components/Server/SpawnerComponent.cs
@@ -129,9 +129,16 @@ namespace Uchu.World
                 {
                     Destroy(obj);
 
-                    await Task.Delay(RespawnTime);
+                    if (LinkedQuickBuildComponent == default)
+                    {
+                        await Task.Delay(RespawnTime);
                     
-                    Spawn();
+                        Spawn();
+                    }
+                    else
+                    {
+                        LinkedQuickBuildComponent.EnableBuildFromSpawner();
+                    }
                 });
             }
 

--- a/Uchu.World/Objects/Components/Server/SpawnerComponent.cs
+++ b/Uchu.World/Objects/Components/Server/SpawnerComponent.cs
@@ -11,6 +11,8 @@ namespace Uchu.World
     public class SpawnerComponent : Component
     {
         private readonly Random _random;
+
+        private QuickBuildComponent LinkedQuickBuildComponent;
         
         public List<GameObject> ActiveSpawns { get; }
 
@@ -142,6 +144,11 @@ namespace Uchu.World
             {
                 Spawn();
             }
+        }
+
+        public void LinkQuickBuildComponent(QuickBuildComponent quickBuildComponent)
+        {
+            LinkedQuickBuildComponent = quickBuildComponent;
         }
     }
 }

--- a/Uchu.World/Objects/GameObjects/GameObject.cs
+++ b/Uchu.World/Objects/GameObjects/GameObject.cs
@@ -603,5 +603,7 @@ namespace Uchu.World
         }
 
         #endregion
+        
+        public static GameObject InvalidObject => new GameObject();
     }
 }

--- a/Uchu.World/Objects/GameObjects/Player.cs
+++ b/Uchu.World/Objects/GameObjects/Player.cs
@@ -373,10 +373,6 @@ namespace Uchu.World
             {
                 Zone.SendConstruction(gameObject, this);
             }
-            else if (spawned && !view)
-            {
-                Zone.SendDestruction(gameObject, this);
-            }
         }
 
         /// <summary>

--- a/Uchu.World/Objects/GameObjects/Player.cs
+++ b/Uchu.World/Objects/GameObjects/Player.cs
@@ -373,6 +373,10 @@ namespace Uchu.World
             {
                 Zone.SendConstruction(gameObject, this);
             }
+            else if (spawned && !view)
+            {
+                Zone.SendDestruction(gameObject, this);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Closes https://github.com/UchuServer/Uchu/issues/60

Some smashables in Lego Universe expose a quick build when smashed, and the smashable respawns after the quick build expires. This pull request implements this behavior instead of the existing behavior where the smashable instantly respawns and the quick build is always visible.