### PR TITLE
Improve Forbidden Valley Load Times

### DIFF
--- a/Uchu.Core/IO/LocalResources.cs
+++ b/Uchu.Core/IO/LocalResources.cs
@@ -91,9 +91,12 @@ namespace Uchu.Core.IO
                 throw new ArgumentNullException(nameof(path), 
                     ResourceStrings.LocalResources_GetStream_PathNullException);
             
-            path = path.Replace('\\', '/').ToLower();
-
-            return File.OpenRead(Path.Combine(RootPath, path));
+            var data = File.ReadAllBytes(Path.Combine(RootPath,path));
+            var stream = new MemoryStream(data.Length);
+            stream.Write(data);
+            stream.Flush();
+            stream.Position = 0;
+            return stream;
         }
     }
 }


### PR DESCRIPTION
Load times for Forbidden Valley are currently several minutes, which is due to an IO bottleneck when parsing the .lvl files in InfectedRose. This pull request changes the file opening method to load the entire file into memory for parsing instead of relying on gradually reading the file. This change reduces the load times to <25 seconds on my system for Forbidden Valley.