### PR TITLE
Add warnings and checks for misconfigurations

### DIFF
--- a/Uchu.Api/ApiManager.cs
+++ b/Uchu.Api/ApiManager.cs
@@ -189,7 +189,7 @@ namespace Uchu.Api
             {
                 json = await client.GetStringAsync(url);
             }
-            catch (HttpRequestException)
+            catch (Exception e) when (e is HttpRequestException || e is UriFormatException)
             {
                 return default;
             }

--- a/Uchu.Core/Config/UchuConfiguration.cs
+++ b/Uchu.Core/Config/UchuConfiguration.cs
@@ -82,6 +82,11 @@ namespace Uchu.Core.Config
         /// Optional Redis cache configuration
         /// </summary>
         [XmlElement("Cache")] public CacheConfig CacheConfig { get; set; } = new CacheConfig();
+        
+        /// <summary>
+        /// General behaviour of the program
+        /// </summary>
+        [XmlElement("ServerBehaviour")] public ServerBehaviour ServerBehaviour { get; set; } = new ServerBehaviour();
     }
 
     /// <summary>
@@ -145,10 +150,7 @@ namespace Uchu.Core.Config
         /// The path to the script source DLLs
         /// </summary>
         [XmlElement]
-        public List<string> ScriptDllSource { get; } = new List<string>
-        {
-            "Uchu.StandardScripts"
-        };
+        public List<string> ScriptDllSource { get; } = new List<string>();
     }
 
     /// <summary>
@@ -306,5 +308,16 @@ namespace Uchu.Core.Config
         /// Whether or not AI wanders around
         /// </summary>
         [XmlElement] public bool AiWander { get; set; }
+    }
+
+    /// <summary>
+    /// Behaviour of the program
+    /// </summary>
+    public class ServerBehaviour
+    {
+        /// <summary>
+        /// Whether the server should display a "Press any key to exit" prompt before exiting due to a fatal error
+        /// </summary>
+        [XmlElement] public bool PressKeyToExit { get; set; } = true;
     }
 }

--- a/Uchu.Core/Logging/LogQueue.cs
+++ b/Uchu.Core/Logging/LogQueue.cs
@@ -12,18 +12,18 @@ namespace Uchu.Core
 {
     public class LogEntry
     {
-        public string message { get; set; }
-        public ConsoleColor color { get; set; }
-        public LogLevel logLevel { get; set; }
-        public StackTrace trace { get; set; }
-        public LogEntry nextEntry { get; set; }
+        public string Message { get; set; }
+        public ConsoleColor Color { get; set; }
+        public LogLevel LogLevel { get; set; }
+        public StackTrace Trace { get; set; }
+        public LogEntry NextEntry { get; set; }
     }
     
     public class LogQueue : IDisposable
     {
-        private readonly Mutex logMutex = new Mutex();
-        private LogEntry nextEntry = null;
-        private LogEntry lastEntry = null;
+        private readonly Mutex _logMutex = new Mutex();
+        private LogEntry _nextEntry = null;
+        private LogEntry _lastEntry = null;
         
         public static UchuConfiguration Config { get; set; }
         
@@ -37,33 +37,33 @@ namespace Uchu.Core
 #endif
         {
             // Lock the log.
-            logMutex.WaitOne();
+            _logMutex.WaitOne();
             
             // Create the new entry.
             var entry = new LogEntry()
             {
-                message = line,
-                color = color,
+                Message = line,
+                Color = color,
 #if DEBUG
-                trace = trace,
+                Trace = trace,
 #endif
-                logLevel = logLevel
+                LogLevel = logLevel
             };
             
             // Update the pointers.
-            if (this.nextEntry == null)
+            if (this._nextEntry == null)
             {
-                this.nextEntry = entry;
-                this.lastEntry = entry;
+                this._nextEntry = entry;
+                this._lastEntry = entry;
             }
             else
             {
-                this.lastEntry.nextEntry = entry;
-                this.lastEntry = entry;
+                this._lastEntry.NextEntry = entry;
+                this._lastEntry = entry;
             }
 
             // Unlock the log.
-            this.logMutex.ReleaseMutex();
+            this._logMutex.ReleaseMutex();
         }
 
         /// <summary>
@@ -73,18 +73,18 @@ namespace Uchu.Core
         public LogEntry PopEntry()
         {
             // Lock the log.
-            logMutex.WaitOne();
+            _logMutex.WaitOne();
             
             // Pop the next entry.
             LogEntry entry = null;
-            if (this.nextEntry != null)
+            if (this._nextEntry != null)
             {
-                entry = this.nextEntry;
-                this.nextEntry = entry.nextEntry;
+                entry = this._nextEntry;
+                this._nextEntry = entry.NextEntry;
             }
             
             // Unlock the log.
-            this.logMutex.ReleaseMutex();
+            this._logMutex.ReleaseMutex();
             
             // Return the entry.
             return entry;
@@ -136,9 +136,9 @@ namespace Uchu.Core
                     var entry = this.PopEntry();
                     while (entry != null)
                     {
-                        if (entry.message.Contains('\n', StringComparison.InvariantCulture))
+                        if (entry.Message.Contains('\n', StringComparison.InvariantCulture))
                         {
-                            var parts = entry.message.Split('\n');
+                            var parts = entry.Message.Split('\n');
 
                             var visual = parts.Max(p => p.Length);
 
@@ -149,7 +149,7 @@ namespace Uchu.Core
                                 var segment = $"{part}{padding}";
 
 #if DEBUG
-                                await InternalLog(segment, entry.color, entry.logLevel, entry.trace).ConfigureAwait(false);
+                                await InternalLog(segment, entry.Color, entry.LogLevel, entry.Trace).ConfigureAwait(false);
 #else
                                 await InternalLog(segment, entry.color, entry.logLevel).ConfigureAwait(false);
 #endif
@@ -158,7 +158,7 @@ namespace Uchu.Core
                             continue;
                         }
 #if DEBUG
-                        await InternalLog(entry.message, entry.color, entry.logLevel, entry.trace).ConfigureAwait(false);
+                        await InternalLog(entry.Message, entry.Color, entry.LogLevel, entry.Trace).ConfigureAwait(false);
 #else
                         await InternalLog(entry.message, entry.color, entry.logLevel).ConfigureAwait(false);
 #endif
@@ -228,7 +228,7 @@ namespace Uchu.Core
         {
             if (disposing)
             {
-                this.logMutex.Dispose();
+                this._logMutex.Dispose();
             }
         }
 

--- a/Uchu.Core/Logging/Logger.cs
+++ b/Uchu.Core/Logging/Logger.cs
@@ -1,8 +1,5 @@
 using System;
 using System.Diagnostics;
-using System.IO;
-using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 using Uchu.Core.Config;
 
@@ -10,8 +7,6 @@ namespace Uchu.Core
 {
     public static class Logger
     {
-        public static UchuConfiguration Config { get; set; }
-
         private static LogQueue logQueue = new LogQueue();
 
         private static bool outputTaskStarted = false;
@@ -41,174 +36,64 @@ namespace Uchu.Core
 
         public static void Debug(object content)
         {
+            if (content is null) throw new ArgumentNullException(nameof(content));
 #if DEBUG
             var trace = new StackTrace();
-
-            Task.Run(() => { InternalLog(content.ToString(), LogLevel.Debug, ConsoleColor.Green, trace); });
-#else
-            Task.Run(() => { InternalLog(content.ToString(), LogLevel.Debug, ConsoleColor.Green); });
+            AddToQueue(content.ToString(), LogLevel.Debug, ConsoleColor.Green, trace);
 #endif
         }
 
         public static void Information(object content)
         {
+            if (content is null) throw new ArgumentNullException(nameof(content));
 #if DEBUG
             var trace = new StackTrace();
-
-            Task.Run(() => { InternalLog(content.ToString(), LogLevel.Information, ConsoleColor.White, trace); });
+            AddToQueue(content.ToString(), LogLevel.Information, ConsoleColor.White, trace); 
 #else
-            Task.Run(() => { InternalLog(content.ToString(), LogLevel.Information, ConsoleColor.White); });
+            AddToQueue(content.ToString(), LogLevel.Information, ConsoleColor.White);
 #endif
         }
 
         public static void Warning(object content)
         {
+            if (content is null) throw new ArgumentNullException(nameof(content));
 #if DEBUG
             var trace = new StackTrace();
-
-            Task.Run(() => { InternalLog(content.ToString(), LogLevel.Warning, ConsoleColor.Yellow, trace); });
+            AddToQueue(content.ToString(), LogLevel.Warning, ConsoleColor.Yellow, trace);
 #else
-            Task.Run(() => { InternalLog(content.ToString(), LogLevel.Warning, ConsoleColor.Yellow); });
+            AddToQueue(content.ToString(), LogLevel.Warning, ConsoleColor.Yellow);
 #endif
         }
 
         public static void Error(object content)
         {
+            if (content is null) throw new ArgumentNullException(nameof(content));
 #if DEBUG
             var trace = new StackTrace();
-
-            Task.Run(() => { InternalLog(content.ToString(), LogLevel.Error, ConsoleColor.Red, trace); });
+            AddToQueue(content.ToString(), LogLevel.Error, ConsoleColor.Red, trace); 
 #else
-            Task.Run(() => { InternalLog(content.ToString(), LogLevel.Error, ConsoleColor.Red); });
+            AddToQueue(content.ToString(), LogLevel.Error, ConsoleColor.Red);
 #endif
         }
 
 #if DEBUG
-        private static void InternalLog(string message, LogLevel logLevel, ConsoleColor color, StackTrace trace)
+        private static void AddToQueue(string message, LogLevel logLevel, ConsoleColor color, StackTrace trace)
 #else
-        private static void InternalLog(string message, LogLevel logLevel, ConsoleColor color)
+        private static void AddToQueue(string message, LogLevel logLevel, ConsoleColor color)
 #endif
         {
-            if (message.Contains('\n', StringComparison.InvariantCulture))
-            {
-                var parts = message.Split('\n');
-
-                var visual = parts.Max(p => p.Length);
-
-                foreach (var part in parts)
-                {
-                    var padding = new string(Enumerable.Repeat(' ', visual - part.Length).ToArray());
-
-                    var segment = $"{part}{padding}";
-
 #if DEBUG
-                    InternalLog(segment, logLevel, color, trace);
-
-                    trace = default;
+            logQueue.AddLine(message, logLevel, color, trace);
 #else
-                    InternalLog(segment, logLevel, color);
-#endif
-                }
-
-                return;
-            }
-
-            {
-                var level = logLevel.ToString();
-
-                var padding = new string(Enumerable.Repeat(' ', 12 - level.Length).ToArray());
-
-                message = $"[{level}]{padding} {message}";
-
-#if DEBUG
-                var amount = 140 - message.Length;
-                padding = new string(Enumerable.Repeat(' ', amount > 0 ? amount : 1).ToArray());
-
-                message = $"{message}{padding}|";
-
-                if (trace != default)
-                {
-                    var invoker = TraceInvoker(trace);
-
-                    if (invoker?.DeclaringType != default)
-                        message = $"{message} {invoker.DeclaringType.Name}.{invoker.Name}";
-                }
+            logQueue.AddLine(message, logLevel, color);
 #endif
 
-                var configuration = Config.ConsoleLogging;
-
-                var consoleLogLevel = Enum.Parse<LogLevel>(configuration.Level);
-
-                string finalMessage;
-
-                if (consoleLogLevel <= logLevel)
-                {
-                    finalMessage = configuration.Timestamp ? $"[{GetCurrentTime()}] {message}" : message;
-                    logQueue.AddLine(finalMessage,color);
-
-                    if (!outputTaskStarted)
-                    {
-                        outputTaskStarted = true;
-                        logQueue.StartConsoleOutput();
-                    }
-                }
-
-                configuration = Config.FileLogging;
-
-                var fileLogLevel = Enum.Parse<LogLevel>(configuration.Level);
-
-                if (fileLogLevel == LogLevel.None || fileLogLevel > logLevel) return;
-
-                var file = configuration.File;
-
-                finalMessage = configuration.Timestamp ? $"[{GetCurrentTime()}] {message}" : message;
-
-                File.AppendAllTextAsync(file, $"{finalMessage}\n");
-            }
-        }
-
-        public static string GetCurrentTime()
-        {
-            return DateTime.Now.ToString("MM/dd/yyyy hh:mm:ss.fff tt");
-        }
-
-#if DEBUG
-        private static MethodBase TraceInvoker(StackTrace trace)
-        {
-            var frames = trace.GetFrames();
-
-            var avoid = new[]
+            if (!outputTaskStarted)
             {
-                typeof(Logger)
-            };
-
-            foreach (var frame in frames)
-            {
-                if (frame == default) continue;
-
-                var method = frame.GetMethod();
-
-                var type = method.DeclaringType;
-
-                if (type?.Namespace == default) continue;
-                
-                var attribute = type.GetCustomAttribute<LoggerIgnoreAttribute>();
-
-                if (avoid.Contains(type) || attribute != null) continue;
-
-                if (type.Namespace != null && !type.Namespace.StartsWith(
-                    "Uchu", StringComparison.InvariantCulture)
-                ) continue;
-
-                if (type.Name.Contains('<', StringComparison.InvariantCulture)) continue;
-
-                if (method.Name.Contains('<', StringComparison.InvariantCulture)) continue;
-
-                return method;
+                outputTaskStarted = true;
+                logQueue.StartConsoleOutput();
             }
-
-            return default;
+            
         }
-#endif
     }
 }

--- a/Uchu.Core/UchuServer.cs
+++ b/Uchu.Core/UchuServer.cs
@@ -180,7 +180,7 @@ namespace Uchu.Core
             {
                 using (var xmlReader = XmlReader.Create(fs))
                 {
-                    Logger.Config = Config = (UchuConfiguration) serializer.Deserialize(xmlReader);
+                    LogQueue.Config = Config = (UchuConfiguration) serializer.Deserialize(xmlReader);
                     UchuContextBase.Config = Config;
                 }
             }

--- a/Uchu.Master/Api/MasterCommands.cs
+++ b/Uchu.Master/Api/MasterCommands.cs
@@ -239,6 +239,24 @@ namespace Uchu.Master.Api
             return response;
         }
 
+        [ApiCommand("master/die")]
+        public void KillMaster(string error = "Fatal error; killing server.")
+        {
+            Logger.Error(error);
+
+            foreach (ServerInstance instance in MasterServer.Instances.ToList())
+            {
+                DecommissionInstance(instance.Id.ToString());
+            }
+            
+            if (MasterServer.Config.ServerBehaviour.PressKeyToExit)
+            {
+                Logger.Error("Press any key to exit...");
+                Console.ReadKey();
+            }
+            
+            Environment.Exit(1);
+        }
 
         [ApiCommand("instance/decommission")]
         public object DecommissionInstance(string id)

--- a/Uchu.Master/MasterServer.cs
+++ b/Uchu.Master/MasterServer.cs
@@ -180,11 +180,11 @@ namespace Uchu.Master
             if (File.Exists(fn))
             {
                 await using var file = File.OpenRead(fn);
-                Logger.Config = Config = (UchuConfiguration) serializer.Deserialize(file);
+                LogQueue.Config = Config = (UchuConfiguration) serializer.Deserialize(file);
             }
             else
             {
-                Logger.Config = Config = new UchuConfiguration();
+                LogQueue.Config = Config = new UchuConfiguration();
 
                 var backup = File.CreateText("config.default.xml");
 


### PR DESCRIPTION
Closes #147.

 - When a fatal misconfiguration is encountered, the server exits.
 - When this happens, the server displays a "Press any key to exit" message, to prevent windows from being closed before the user can read the error message. As this might be problematic for automated (re)starting of the server, this prompt can be disabled by setting the newly added `ServerBehaviour -> PressKeyToExit` to `false` in config.xml.

Misconfigurations for which a nice error is displayed:
 - Authentication, Character or API port is unavailable, requires elevated privileges, or is not a valid port
 - Path to Uchu.Instance.dll is incorrect
 - One of the script pack dll paths is incorrect (displays a warning at startup; does not exit the entire process)
 - World server cannot start (displays an error, but does not exit the entire process)