### PR TITLE
Bugs/level up on world load

### DIFF
--- a/Uchu.World/Handlers/Commands/CharacterCommandHandler.cs
+++ b/Uchu.World/Handlers/Commands/CharacterCommandHandler.cs
@@ -459,7 +459,7 @@ namespace Uchu.World.Handlers.Commands
             if (!int.TryParse(arguments[0], out var delta)) return "Invalid <delta>";
 
             var character = player.GetComponent<CharacterComponent>();
-            await character.IncrementUniverseScoreAsync(delta);
+            character.UniverseScore += delta;
 
             GameObject.Serialize(player);
 

--- a/Uchu.World/Handlers/Commands/CharacterCommandHandler.cs
+++ b/Uchu.World/Handlers/Commands/CharacterCommandHandler.cs
@@ -452,14 +452,14 @@ namespace Uchu.World.Handlers.Commands
         }
 
         [CommandHandler(Signature = "score", Help = "Change your U-score", GameMasterLevel = GameMasterLevel.Admin)]
-        public string Score(string[] arguments, Player player)
+        public async Task<string> Score(string[] arguments, Player player)
         {
             if (arguments.Length != 1) return "score <delta>";
 
             if (!int.TryParse(arguments[0], out var delta)) return "Invalid <delta>";
 
             var character = player.GetComponent<CharacterComponent>();
-            character.UniverseScore += delta;
+            await character.IncrementUniverseScoreAsync(delta);
 
             GameObject.Serialize(player);
 
@@ -474,7 +474,7 @@ namespace Uchu.World.Handlers.Commands
             if (!long.TryParse(arguments[0], out var level)) return "Invalid <level>";
 
             var character = player.GetComponent<CharacterComponent>();
-            await character.SetLevel(level);
+            await character.SetLevelAsync(level);
 
             GameObject.Serialize(player);
 

--- a/Uchu.World/Objects/Components/ReplicaComponents/CharacterComponent.cs
+++ b/Uchu.World/Objects/Components/ReplicaComponents/CharacterComponent.cs
@@ -36,7 +36,7 @@ namespace Uchu.World
                 return;
 
             Currency = character.Currency;
-            UniverseScore = character.UniverseScore;
+            _universeScore = character.UniverseScore;
             await SetLevelAsync(character.Level, false);
 
             BaseHealth = character.BaseHealth;
@@ -443,30 +443,34 @@ namespace Uchu.World
         /// <summary>
         /// A player's LU score
         /// </summary>
-        public long UniverseScore { get; private set; }
+        private long _universeScore;
+
+        /// <summary>
+        /// A player's LU score
+        /// </summary>
+        public long UniverseScore
+        {
+            get => _universeScore;
+            set
+            {
+                var oldScore = UniverseScore;
+                _universeScore = value;
+            
+                if (GameObject is Player player)
+                {
+                    player.Message(new ModifyLegoScoreMessage
+                    {
+                        Associate = player,
+                        Score = UniverseScore - oldScore
+                    });
+                }
+            }
+        }
         
         /// <summary>
         /// The universe score required to reach the next level
         /// </summary>
         public long RequiredUniverseScore { get; private set; }
-
-        /// <summary>
-        /// Sets the universe score and notifies the client about the update
-        /// </summary>
-        /// <param name="scoreDelta">The score to set</param>
-        public async Task IncrementUniverseScoreAsync(long scoreDelta)
-        {
-            UniverseScore += scoreDelta;
-            
-            if (GameObject is Player player)
-            {
-                player.Message(new ModifyLegoScoreMessage
-                {
-                    Associate = player,
-                    Score = scoreDelta
-                });
-            }
-        }
 
         /// <summary>
         /// The level a player is currently at

--- a/Uchu.World/Objects/Components/ReplicaComponents/CharacterComponent.cs
+++ b/Uchu.World/Objects/Components/ReplicaComponents/CharacterComponent.cs
@@ -489,9 +489,9 @@ namespace Uchu.World
         /// <param name="notifyClient">Whether to send the updated level to the client</param>
         public async Task SetLevelAsync(long level, bool notifyClient = true)
         {
-            // Level 0 doesn't exist, so we have to set it to level 1
+            // Level 0 does not exist, set to 1 by default
             level = level == 0 ? 1 : level;
-            
+
             // Make sure the level exists
             var levelLookup = (await ClientCache.GetTableAsync<LevelProgressionLookup>())
                 .FirstOrDefault(l => l.Id == level);

--- a/Uchu.World/Systems/Missions/MissionInstance.cs
+++ b/Uchu.World/Systems/Missions/MissionInstance.cs
@@ -467,7 +467,7 @@ namespace Uchu.World.Systems.Missions
         /// rewarded if it's in one of the mission rewards.</param>
         private async Task SendRewardsAsync(int rewardItem)
         {
-            RewardPlayerCurrency();
+            await RewardCurrencyAndScoreAsync();
             RewardPlayerEmotes();
             RewardPlayerStats();
             await RewardPlayerLootAsync(rewardItem);
@@ -481,7 +481,7 @@ namespace Uchu.World.Systems.Missions
         /// If this is an achievement the currency is updated silently without a notify message
         /// as the client updates the currency locally.
         /// </remarks>
-        private void RewardPlayerCurrency()
+        private async Task RewardCurrencyAndScoreAsync()
         {
 
             if (!Player.TryGetComponent<CharacterComponent>(out var character))
@@ -493,14 +493,14 @@ namespace Uchu.World.Systems.Missions
             if (IsMission)
             {
                 character.Currency += currency;
-                character.UniverseScore += score;
+                await character.IncrementUniverseScoreAsync(score);
             }
             else
             {
                 // TODO: Silent?
                 // Achievement, client adds these itself so we don't need to notify
                 character.Currency += currency;
-                character.UniverseScore += score;
+                await character.IncrementUniverseScoreAsync(score);
 
                 // The client adds currency rewards as an offset, in my testing. Therefore we
                 // have to account for this offset.

--- a/Uchu.World/Systems/Missions/MissionInstance.cs
+++ b/Uchu.World/Systems/Missions/MissionInstance.cs
@@ -493,14 +493,14 @@ namespace Uchu.World.Systems.Missions
             if (IsMission)
             {
                 character.Currency += currency;
-                await character.IncrementUniverseScoreAsync(score);
+                character.UniverseScore += score;
             }
             else
             {
                 // TODO: Silent?
                 // Achievement, client adds these itself so we don't need to notify
                 character.Currency += currency;
-                await character.IncrementUniverseScoreAsync(score);
+                character.UniverseScore += score;
 
                 // The client adds currency rewards as an offset, in my testing. Therefore we
                 // have to account for this offset.


### PR DESCRIPTION
This PR aims to fix two issues:

- Levels don't save to the database
- On world load the Universe score is added to the base score

It does this by refactoring quite a bit of the leveling system: level ups are now stored in the character component instead of directly to the database in the level up packet handler. I also noticed that you never actually leveled up in Uchu, it would store your LU score and then when loading into a world the client would level you up to the required level on world load, the level is now properly stored and sent on world load.