### PR TITLE
Improve Moving Platforms

### DIFF
--- a/Uchu.StandardScripts/AvantGardens/BusDoor.cs
+++ b/Uchu.StandardScripts/AvantGardens/BusDoor.cs
@@ -23,12 +23,13 @@ namespace Uchu.StandardScripts.AvantGardens
                 movingPlatformComponent.Stop();
                 
                 var physics = gameObject.AddComponent<PhysicsComponent>();
-                var physicsObject = BoxBody.Create(
+
+                var physicsObject = CylinderBody.Create(
                     gameObject.Zone.Simulation,
                     gameObject.Transform.Position,
-                    gameObject.Transform.Rotation, 
-                    new Vector3(190,190,190)
-                );
+                    gameObject.Transform.Rotation,
+                    new Vector2(85, 190));
+                
                 physics.SetPhysics(physicsObject);
 
                 // Set up players entering and leaving.

--- a/Uchu.StandardScripts/AvantGardens/BusDoor.cs
+++ b/Uchu.StandardScripts/AvantGardens/BusDoor.cs
@@ -1,0 +1,55 @@
+using System.Numerics;
+using System.Threading.Tasks;
+using Uchu.World;
+using Uchu.World.Scripting.Native;
+
+namespace Uchu.StandardScripts.AvantGardens
+{
+    [ZoneSpecific(1100)]
+    public class BusDoor : NativeScript
+    {
+        public override Task LoadAsync()
+        {
+            var gameObjects = HasLuaScript("l_ag_bus_door.lua");
+
+            foreach (var gameObject in gameObjects)
+            {
+                if (!gameObject.TryGetComponent<MovingPlatformComponent>(out var movingPlatformComponent)) continue;
+                movingPlatformComponent.Stop();
+                
+                bool doorOpen = default;
+                Listen(Zone.OnTick, () =>
+                {
+                    if (movingPlatformComponent.State != PlatformState.Idle) return;
+                    
+                    var playerInRadius = false;
+                    foreach (var player in Zone.Players)
+                    {
+                        if (player?.Transform == default) continue;
+
+                        var radius = Vector3.Distance(player.Transform.Position, gameObject.Transform.Position);
+                        if (radius > 85) continue;
+                        
+                        playerInRadius = true;
+                        break;
+                    }
+
+                    if (doorOpen != playerInRadius)
+                    {
+                        doorOpen = playerInRadius;
+                        if (doorOpen)
+                        {
+                            movingPlatformComponent.MoveTo(1);
+                        }
+                        else
+                        {
+                            movingPlatformComponent.MoveTo(0);
+                        }
+                    }
+                });
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Uchu.StandardScripts/AvantGardens/BusDoor.cs
+++ b/Uchu.StandardScripts/AvantGardens/BusDoor.cs
@@ -43,7 +43,10 @@ namespace Uchu.StandardScripts.AvantGardens
                         }
                         else
                         {
-                            movingPlatformComponent.MoveTo(0);
+                            movingPlatformComponent.MoveTo(0, () =>
+                            {
+                                gameObject.PlayFX("busDust", "create", 642);
+                            });
                         }
                     }
                 });

--- a/Uchu.StandardScripts/AvantGardens/BusDoor.cs
+++ b/Uchu.StandardScripts/AvantGardens/BusDoor.cs
@@ -1,5 +1,7 @@
+using System.Collections.Generic;
 using System.Numerics;
 using System.Threading.Tasks;
+using Uchu.Physics;
 using Uchu.World;
 using Uchu.World.Scripting.Native;
 
@@ -8,6 +10,9 @@ namespace Uchu.StandardScripts.AvantGardens
     [ZoneSpecific(1100)]
     public class BusDoor : NativeScript
     {
+        private List<Player> _playersInRadius = new List<Player>();
+        private bool _doorOpen = false;
+        
         public override Task LoadAsync()
         {
             var gameObjects = HasLuaScript("l_ag_bus_door.lua");
@@ -17,42 +22,75 @@ namespace Uchu.StandardScripts.AvantGardens
                 if (!gameObject.TryGetComponent<MovingPlatformComponent>(out var movingPlatformComponent)) continue;
                 movingPlatformComponent.Stop();
                 
-                bool doorOpen = default;
-                Listen(Zone.OnTick, () =>
+                var physics = gameObject.AddComponent<PhysicsComponent>();
+                var physicsObject = BoxBody.Create(
+                    gameObject.Zone.Simulation,
+                    gameObject.Transform.Position,
+                    gameObject.Transform.Rotation, 
+                    new Vector3(190,190,190)
+                );
+                physics.SetPhysics(physicsObject);
+
+                // Set up players entering and leaving.
+                Listen(physics.OnEnter, (other) =>
                 {
-                    if (movingPlatformComponent.State != PlatformState.Idle) return;
-                    
-                    var playerInRadius = false;
-                    foreach (var player in Zone.Players)
-                    {
-                        if (player?.Transform == default) continue;
+                    if (!(other.GameObject is Player player)) return;
+                    if (_playersInRadius.Contains(player)) return;
+                    _playersInRadius.Add(player);
+                    UpdateDoor(gameObject);
+                });
+                
+                Listen(physics.OnLeave, (other) =>
+                {
+                    if (!(other.GameObject is Player player)) return;
+                    if (!_playersInRadius.Contains(player)) return;
+                    _playersInRadius.Remove(player);
+                    UpdateDoor(gameObject);
+                });
 
-                        var radius = Vector3.Distance(player.Transform.Position, gameObject.Transform.Position);
-                        if (radius > 85) continue;
-                        
-                        playerInRadius = true;
-                        break;
-                    }
-
-                    if (doorOpen != playerInRadius)
+                // Set up player disconnecting so that players disconnecting near the door don't keep it open.
+                Listen(Zone.OnPlayerLoad, (player) =>
+                {
+                    Listen(player.OnDestroyed, () =>
                     {
-                        doorOpen = playerInRadius;
-                        if (doorOpen)
-                        {
-                            movingPlatformComponent.MoveTo(1);
-                        }
-                        else
-                        {
-                            movingPlatformComponent.MoveTo(0, () =>
-                            {
-                                gameObject.PlayFX("busDust", "create", 642);
-                            });
-                        }
-                    }
+                        if (!_playersInRadius.Contains(player)) return;
+                        _playersInRadius.Remove(player);
+                        UpdateDoor(gameObject);
+                    });
                 });
             }
 
             return Task.CompletedTask;
+        }
+
+        private void UpdateDoor(GameObject door)
+        {
+            // Return if the door is moving.
+            // If the intended open state changed, it will be updated when the move ends.
+            if (!door.TryGetComponent<MovingPlatformComponent>(out var movingPlatformComponent)) return;
+            if (movingPlatformComponent.State != PlatformState.Idle) return;
+            
+            // Return if the door is already open to reduce updates.
+            var doorShouldBeOpen = _playersInRadius.Count > 0;
+            if (doorShouldBeOpen == _doorOpen) return;
+            _doorOpen = doorShouldBeOpen;
+            
+            // Open or close the door, then update again in case the intended state changed mid-movement.
+            if (_doorOpen)
+            {
+                movingPlatformComponent.MoveTo(1, () =>
+                {
+                    UpdateDoor(door);
+                });
+            }
+            else
+            {
+                movingPlatformComponent.MoveTo(0, () =>
+                {
+                    door.PlayFX("busDust", "create", 642);
+                    UpdateDoor(door);
+                });
+            }
         }
     }
 }

--- a/Uchu.World/Handlers/GameMessages/GeneralHandler.cs
+++ b/Uchu.World/Handlers/GameMessages/GeneralHandler.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
@@ -124,6 +125,24 @@ namespace Uchu.World.Handlers.GameMessages
                 });
 
                 player.Zone.BroadcastChatMessage($"{character.Name} has reached Level {character.Level}!");
+            }
+        }
+
+        [PacketHandler]
+        public void RequestPlatformResyncHandler(RequestPlatformResyncMessage message, Player player)
+        {
+            if (message.Associate.TryGetComponent<MovingPlatformComponent>(out var movingPlatformComponent))
+            {
+                player.Message(new PlatformResyncMessage()
+                {
+                    State = movingPlatformComponent.State,
+                    IdleTimeElapsed = movingPlatformComponent.IdleTimeElapsed,
+                    PercentBetweenPoints = movingPlatformComponent.PercentBetweenPoints,
+                    Index = (int) movingPlatformComponent.CurrentWaypointIndex,
+                    NextIndex = (int) movingPlatformComponent.NextWaypointIndex,
+                    UnexpectedLocation = movingPlatformComponent.TargetPosition,
+                    UnexpectedRotation = movingPlatformComponent.TargetRotation,
+                });
             }
         }
     }

--- a/Uchu.World/Handlers/PositionUpdateHandler.cs
+++ b/Uchu.World/Handlers/PositionUpdateHandler.cs
@@ -32,7 +32,7 @@ namespace Uchu.World.Handlers
 
             physics.AngularVelocity = packet.AngularVelocity;
 
-            physics.Platform = default; //player.Zone.GameObjects.FirstOrDefault(g => g.ObjectId == packet.PlatformObjectId);
+            physics.Platform = player.Zone.GameObjects.FirstOrDefault(g => g.Id == packet.PlatformObjectId);
 
             physics.PlatformPosition = packet.PlatformPosition;
 

--- a/Uchu.World/Objects/Components/ReplicaComponents/MovingPlatformComponent.cs
+++ b/Uchu.World/Objects/Components/ReplicaComponents/MovingPlatformComponent.cs
@@ -93,6 +93,11 @@ namespace Uchu.World
                 
                 Task.Run(() => WaitPoint());
 
+                if (GameObject.TryGetComponent<SimplePhysicsComponent>(out var simplePhysicsComponent))
+                {
+                    simplePhysicsComponent.HasPosition = false;
+                }
+
                 if (!GameObject.TryGetComponent<QuickBuildComponent>(out var quickBuildComponent)) return;
                 Listen(quickBuildComponent.OnStateChange,(state) =>
                 {
@@ -110,16 +115,21 @@ namespace Uchu.World
             });
         }
 
-        public override void Construct(BitWriter writer)
+        public override void Construct(BitWriter writer) 
         {
-            Serialize(writer);
+            Serialize(writer,true);
         }
 
         public override void Serialize(BitWriter writer)
         {
+            Serialize(writer,false);
+        }
+        
+        public void Serialize(BitWriter writer,bool includePath)
+        {
             writer.WriteBit(true);
 
-            var hasPath = PathName != null;
+            var hasPath = includePath && PathName != null;
 
             writer.WriteBit(hasPath);
 
@@ -191,7 +201,6 @@ namespace Uchu.World
             NextWaypointIndex = NextIndex;
             _currentDuration = (WayPoint.Position - NextWayPoint.Position).Length() / WayPoint.Speed;
             _wayPointStartTime = (DateTime.UtcNow - new DateTime(1970,1,1,0,0,0)).TotalSeconds;
-            PathName = Path.PathName;
             State = PlatformState.Move;
             TargetPosition = WayPoint.Position;
             TargetRotation = WayPoint.Rotation;
@@ -227,7 +236,6 @@ namespace Uchu.World
             // Update Object in world.
             _currentDuration = (WayPoint.Position - NextWayPoint.Position).Length() / WayPoint.Speed;
             _wayPointStartTime = (DateTime.UtcNow - new DateTime(1970,1,1,0,0,0)).TotalSeconds;
-            PathName = Path.PathName;
             State = PlatformState.Move;
             TargetPosition = WayPoint.Position;
             TargetRotation = WayPoint.Rotation;
@@ -254,7 +262,6 @@ namespace Uchu.World
             _currentDuration = WayPoint.Wait;
             
             // Update Object in world.
-            PathName = null;
             State = PlatformState.Idle;
             TargetPosition = WayPoint.Position;
             TargetRotation = WayPoint.Rotation;

--- a/Uchu.World/Objects/Components/ReplicaComponents/MovingPlatformComponent.cs
+++ b/Uchu.World/Objects/Components/ReplicaComponents/MovingPlatformComponent.cs
@@ -150,9 +150,14 @@ namespace Uchu.World
 
         private void MovePlatform()
         {
-            /*
-             * Update Object in world.
-             */
+            // Set the timer before the waypoint changes.
+            Timer = new Timer
+            {
+                AutoReset = false,
+                Interval = (WayPoint.Position - NextWayPoint.Position).Length() / WayPoint.Speed * 1000
+            };
+            
+            // Update Object in world.
             PathName = Path.PathName;
             State = PlatformState.Move;
             TargetPosition = WayPoint.Position;
@@ -161,15 +166,7 @@ namespace Uchu.World
 
             GameObject.Serialize(GameObject);
 
-            /*
-             * Start Waiting after completing path.
-             */
-            Timer = new Timer
-            {
-                AutoReset = false,
-                Interval = WayPoint.Speed * 1000
-            };
-
+            // Start Waiting after completing path.
             Timer.Elapsed += (sender, args) => { WaitPoint(); };
 
             Task.Run(() => Timer.Start());
@@ -180,9 +177,7 @@ namespace Uchu.World
             // Move to next path index.
             CurrentWaypointIndex = NextIndex;
 
-            /*
-             * Update Object in world.
-             */
+            // Update Object in world.
             PathName = null;
             State = PlatformState.Idle;
             TargetPosition = WayPoint.Position;
@@ -191,9 +186,7 @@ namespace Uchu.World
             
             GameObject.Serialize(GameObject);
 
-            /*
-             * Start Waiting after waiting.
-             */
+            // Start Waiting after waiting.
             Timer = new Timer
             {
                 AutoReset = false,

--- a/Uchu.World/Objects/Components/ReplicaComponents/MovingPlatformComponent.cs
+++ b/Uchu.World/Objects/Components/ReplicaComponents/MovingPlatformComponent.cs
@@ -232,7 +232,7 @@ namespace Uchu.World
                 Timer.Elapsed += (sender, args) => moveCompleteCallback();
             }
 
-            Task.Run(() => Timer.Start());
+            Timer.Start();
         }
 
         private void MovePlatform()
@@ -255,7 +255,7 @@ namespace Uchu.World
             };
             Timer.Elapsed += (sender, args) => { WaitPoint(); };
 
-            Task.Run(() => Timer.Start());
+            Timer.Start();
         }
 
         private void WaitPoint(int extraWaitTime = 0)
@@ -282,7 +282,7 @@ namespace Uchu.World
 
             Timer.Elapsed += (sender, args) => { MovePlatform(); };
 
-            Task.Run(() => Timer.Start());
+            Timer.Start();
         }
     }
 }

--- a/Uchu.World/Objects/Components/ReplicaComponents/MovingPlatformComponent.cs
+++ b/Uchu.World/Objects/Components/ReplicaComponents/MovingPlatformComponent.cs
@@ -194,7 +194,7 @@ namespace Uchu.World
             State = PlatformState.Idle;
         }
 
-        public void MoveTo(uint position)
+        public void MoveTo(uint position,Action moveCompleteCallback = default)
         {
             // Update Object in world.
             CurrentWaypointIndex = position;
@@ -227,6 +227,10 @@ namespace Uchu.World
             
                 GameObject.Serialize(GameObject);
             };
+            if (moveCompleteCallback != default)
+            {
+                Timer.Elapsed += (sender, args) => moveCompleteCallback();
+            }
 
             Task.Run(() => Timer.Start());
         }

--- a/Uchu.World/Objects/Components/ReplicaComponents/MovingPlatformComponent.cs
+++ b/Uchu.World/Objects/Components/ReplicaComponents/MovingPlatformComponent.cs
@@ -108,8 +108,8 @@ namespace Uchu.World
                     CurrentWaypointIndex = PathStart == 0 ? (uint) (Path.Waypoints.Length - 1) : PathStart - 1;
                     Task.Run(() =>
                     {
-                        // A wait is required at the beginning, otherwise the platform moves right as the player is unfrozen from the building complete animation.
-                        WaitPoint(GameObject.Settings.TryGetValue("compTime", out var compTime) ? (int) ((float) compTime * 1000) : 0);
+                        // TODO: A wait is required at the beginning, otherwise the platform moves right as the player is unfrozen from the building complete animation.
+                        WaitPoint(1);
                     });
                 });
             });

--- a/Uchu.World/Objects/Components/ReplicaComponents/MovingPlatformComponent.cs
+++ b/Uchu.World/Objects/Components/ReplicaComponents/MovingPlatformComponent.cs
@@ -80,7 +80,7 @@ namespace Uchu.World
                 Path = Zone.ZoneInfo.LuzFile.PathData.FirstOrDefault(p =>
                     p is LuzMovingPlatformPath && p.PathName == PathName) as LuzMovingPlatformPath;
 
-                Type = GameObject.Settings.TryGetValue("platformIsMover", out var isMover) && (bool) isMover
+                Type = !GameObject.Settings.TryGetValue("platformIsMover", out var isMover) || (bool) isMover
                     ? PlatformType.Mover
                     : GameObject.Settings.TryGetValue("platformIsSimpleMover", out var isSimpleMover) &&
                       (bool) isSimpleMover

--- a/Uchu.World/Objects/Components/ReplicaComponents/MovingPlatformComponent.cs
+++ b/Uchu.World/Objects/Components/ReplicaComponents/MovingPlatformComponent.cs
@@ -99,7 +99,7 @@ namespace Uchu.World
                 }
 
                 if (!GameObject.TryGetComponent<QuickBuildComponent>(out var quickBuildComponent)) return;
-                Listen(quickBuildComponent.OnStateChange,(state) =>
+                Listen(quickBuildComponent.OnStateChange, (state) =>
                 {
                     if (state != RebuildState.Completed) return;
                     
@@ -117,12 +117,12 @@ namespace Uchu.World
 
         public override void Construct(BitWriter writer) 
         {
-            Serialize(writer,true);
+            Serialize(writer, true);
         }
 
         public override void Serialize(BitWriter writer)
         {
-            Serialize(writer,false);
+            Serialize(writer, false);
         }
         
         public void Serialize(BitWriter writer,bool includePath)
@@ -200,7 +200,7 @@ namespace Uchu.World
             CurrentWaypointIndex = position;
             NextWaypointIndex = NextIndex;
             _currentDuration = (WayPoint.Position - NextWayPoint.Position).Length() / WayPoint.Speed;
-            _wayPointStartTime = (DateTime.UtcNow - new DateTime(1970,1,1,0,0,0)).TotalSeconds;
+            _wayPointStartTime = (DateTime.UtcNow - new DateTime(1970, 1, 1, 0, 0, 0)).TotalSeconds;
             State = PlatformState.Move;
             TargetPosition = WayPoint.Position;
             TargetRotation = WayPoint.Rotation;
@@ -239,7 +239,7 @@ namespace Uchu.World
         {
             // Update Object in world.
             _currentDuration = (WayPoint.Position - NextWayPoint.Position).Length() / WayPoint.Speed;
-            _wayPointStartTime = (DateTime.UtcNow - new DateTime(1970,1,1,0,0,0)).TotalSeconds;
+            _wayPointStartTime = (DateTime.UtcNow - new DateTime(1970, 1, 1, 0, 0, 0)).TotalSeconds;
             State = PlatformState.Move;
             TargetPosition = WayPoint.Position;
             TargetRotation = WayPoint.Rotation;
@@ -262,7 +262,7 @@ namespace Uchu.World
         {
             // Move to next path index.
             CurrentWaypointIndex = NextIndex;
-            _wayPointStartTime = (DateTime.UtcNow - new DateTime(1970,1,1,0,0,0)).TotalSeconds;
+            _wayPointStartTime = (DateTime.UtcNow - new DateTime(1970, 1, 1, 0, 0, 0)).TotalSeconds;
             _currentDuration = WayPoint.Wait;
             
             // Update Object in world.

--- a/Uchu.World/Packets/GameMessages/Client/RequestPlatformResyncMessage.cs
+++ b/Uchu.World/Packets/GameMessages/Client/RequestPlatformResyncMessage.cs
@@ -1,0 +1,7 @@
+namespace Uchu.World
+{
+    public class RequestPlatformResyncMessage : ClientGameMessage
+    {
+        public override GameMessageId GameMessageId => GameMessageId.RequestPlatformResync;
+    }
+}

--- a/Uchu.World/Packets/GameMessages/Server/PlatformResyncMessage.cs
+++ b/Uchu.World/Packets/GameMessages/Server/PlatformResyncMessage.cs
@@ -1,0 +1,54 @@
+using System.Numerics;
+using RakDotNet.IO;
+
+namespace Uchu.World
+{
+    public class PlatformResyncMessage : ServerGameMessage
+    {
+        public override GameMessageId GameMessageId => GameMessageId.PlatformResync;
+
+        public bool Reverse { get; set; }
+
+        public bool StopAtDesiredWaypoint { get; set; }
+        
+        public int Command { get; set; }
+        
+        public PlatformState State { get; set; }
+        
+        public int UnexpectedCommand { get; set; }
+        
+        public float IdleTimeElapsed { get; set; }
+        
+        public float MoveTimeElapsed { get; set; }
+        
+        public float PercentBetweenPoints { get; set; }
+
+        public int DesiredWaypointIndex { get; set; } = -1;
+        
+        public int Index { get; set; }
+        
+        public int NextIndex { get; set; }
+        
+        public Vector3 UnexpectedLocation { get; set; }
+        
+        public Quaternion UnexpectedRotation { get; set; }
+        
+        public override void SerializeMessage(BitWriter writer)
+        {
+            writer.WriteBit(Reverse);
+            writer.WriteBit(StopAtDesiredWaypoint);
+            writer.Write(Command);
+            writer.Write((int) State);
+            writer.Write(UnexpectedCommand);
+            writer.Write(IdleTimeElapsed);
+            writer.Write(MoveTimeElapsed);
+            writer.Write(PercentBetweenPoints);
+            writer.Write(PercentBetweenPoints);
+            writer.Write(DesiredWaypointIndex);
+            writer.Write(Index);
+            writer.Write(NextIndex);
+            writer.Write(UnexpectedLocation);
+            writer.Write(UnexpectedRotation);
+        }
+    }
+}


### PR DESCRIPTION
Closes https://github.com/UchuServer/Uchu/issues/170

This pull request attempts to improve the functionality of moving platforms. The changes include:
- Fix platforms teleporting due to incorrect timings.
- Fix platforms on Crux Prime not moving by default.
- Fix players teleporting off platforms.
- Fix platforms being mid-movement during quick builds.
- Implement the bus door script.