### PR TITLE
Fix Uninitialized Quick Builds

### DIFF
--- a/Uchu.World/Handlers/GameMessages/GeneralHandler.cs
+++ b/Uchu.World/Handlers/GameMessages/GeneralHandler.cs
@@ -74,7 +74,7 @@ namespace Uchu.World.Handlers.GameMessages
         {
             Logger.Debug($"Loaded: {message.GameObject}");
             await player.OnReadyForUpdatesEvent.InvokeAsync(message);
-            Zone.SendSerialization(message.GameObject,new []{ player });
+            Zone.SendSerialization(message.GameObject, new []{ player });
         }
 
         [PacketHandler]

--- a/Uchu.World/Handlers/GameMessages/GeneralHandler.cs
+++ b/Uchu.World/Handlers/GameMessages/GeneralHandler.cs
@@ -74,6 +74,7 @@ namespace Uchu.World.Handlers.GameMessages
         {
             Logger.Debug($"Loaded: {message.GameObject}");
             await player.OnReadyForUpdatesEvent.InvokeAsync(message);
+            Zone.SendSerialization(message.GameObject,new []{ player });
         }
 
         [PacketHandler]


### PR DESCRIPTION
Closes https://github.com/UchuServer/Uchu/issues/166

During the development of `enhancement/improve-platforms`, I found that this occurred with the platform quick builds at the Avant Gardens Monument until they send their serialization as they move. Sending the serialization data after the client sends a ready for updates game message resolves the problem.