### PR TITLE
Fix Character Stats Not Persisting

### DIFF
--- a/Uchu.World/Objects/Components/DestroyableComponent.cs
+++ b/Uchu.World/Objects/Components/DestroyableComponent.cs
@@ -239,6 +239,74 @@ namespace Uchu.World
                     .Split(',')
                     .Select(int.Parse)
                     .ToArray();
+                
+                if (!(GameObject is Player)) return;
+
+                Listen(OnHealthChanged, async (total, delta) =>
+                {
+                    await using var ctx = new UchuContext();
+
+                    var character = await ctx.Characters.FirstAsync(c => c.Id == GameObject.Id);
+
+                    character.CurrentHealth = (int) total;
+
+                    await ctx.SaveChangesAsync();
+                });
+
+                Listen(OnArmorChanged, async (total, delta) =>
+                {
+                    await using var ctx = new UchuContext();
+
+                    var character = await ctx.Characters.FirstAsync(c => c.Id == GameObject.Id);
+
+                    character.CurrentArmor = (int) total;
+
+                    await ctx.SaveChangesAsync();
+                });
+
+                Listen(OnImaginationChanged, async (total, delta) =>
+                {
+                    await using var ctx = new UchuContext();
+
+                    var character = await ctx.Characters.FirstAsync(c => c.Id == GameObject.Id);
+
+                    character.CurrentImagination = (int) total;
+
+                    await ctx.SaveChangesAsync();
+                });
+
+                Listen(OnMaxHealthChanged, async (total, delta) =>
+                {
+                    await using var ctx = new UchuContext();
+
+                    var character = await ctx.Characters.FirstAsync(c => c.Id == GameObject.Id);
+
+                    character.MaximumHealth = (int) total;
+
+                    await ctx.SaveChangesAsync();
+                });
+
+                Listen(OnMaxArmorChanged, async (total, delta) =>
+                {
+                    await using var ctx = new UchuContext();
+
+                    var character = await ctx.Characters.FirstAsync(c => c.Id == GameObject.Id);
+
+                    character.MaximumArmor = (int) total;
+
+                    await ctx.SaveChangesAsync();
+                });
+
+                Listen(OnMaxImaginationChanged, async (total, delta) =>
+                {
+                    await using var ctx = new UchuContext();
+
+                    var character = await ctx.Characters.FirstAsync(c => c.Id == GameObject.Id);
+
+                    character.MaximumImagination = (int) total;
+
+                    await ctx.SaveChangesAsync();
+                });
             });
 
             Listen(OnDestroyed, () =>
@@ -251,74 +319,6 @@ namespace Uchu.World
                 OnMaxImaginationChanged.Clear();
 
                 OnDeath.Clear();
-            });
-
-            if (!(GameObject is Player)) return;
-
-            Listen(OnHealthChanged, async (total, delta) =>
-            {
-                await using var ctx = new UchuContext();
-
-                var character = await ctx.Characters.FirstAsync(c => c.Id == GameObject.Id);
-
-                character.CurrentHealth = (int) total;
-
-                await ctx.SaveChangesAsync();
-            });
-
-            Listen(OnArmorChanged, async (total, delta) =>
-            {
-                await using var ctx = new UchuContext();
-
-                var character = await ctx.Characters.FirstAsync(c => c.Id == GameObject.Id);
-
-                character.CurrentArmor = (int) total;
-
-                await ctx.SaveChangesAsync();
-            });
-
-            Listen(OnImaginationChanged, async (total, delta) =>
-            {
-                await using var ctx = new UchuContext();
-
-                var character = await ctx.Characters.FirstAsync(c => c.Id == GameObject.Id);
-
-                character.CurrentImagination = (int) total;
-
-                await ctx.SaveChangesAsync();
-            });
-
-            Listen(OnMaxHealthChanged, async (total, delta) =>
-            {
-                await using var ctx = new UchuContext();
-
-                var character = await ctx.Characters.FirstAsync(c => c.Id == GameObject.Id);
-
-                character.MaximumHealth = (int) total;
-
-                await ctx.SaveChangesAsync();
-            });
-
-            Listen(OnMaxArmorChanged, async (total, delta) =>
-            {
-                await using var ctx = new UchuContext();
-
-                var character = await ctx.Characters.FirstAsync(c => c.Id == GameObject.Id);
-
-                character.MaximumArmor = (int) total;
-
-                await ctx.SaveChangesAsync();
-            });
-
-            Listen(OnMaxImaginationChanged, async (total, delta) =>
-            {
-                await using var ctx = new UchuContext();
-
-                var character = await ctx.Characters.FirstAsync(c => c.Id == GameObject.Id);
-
-                character.MaximumImagination = (int) total;
-
-                await ctx.SaveChangesAsync();
             });
         }
 


### PR DESCRIPTION
Closes https://github.com/UchuServer/Uchu/issues/197

Due to how the events were set up for saving stats in the database for players, the events would never be initialized since the `GameObject` would be `null`. This change corrects the setup so the events connect and the stats (health, armor, and imagination) persist between sessions.