### PR TITLE
Fix Player Coin Drop On Kill

### DIFF
--- a/Uchu.World/Objects/Components/ReplicaComponents/DestructibleComponent.cs
+++ b/Uchu.World/Objects/Components/ReplicaComponents/DestructibleComponent.cs
@@ -136,9 +136,9 @@ namespace Uchu.World
             });
 
             // Determine whether this was a player or a regular game object
-            if (GameObject is Player)
+            if (GameObject is Player player)
             {
-                GeneratePlayerYieldsAsync(owner);
+                GeneratePlayerYieldsAsync(player);
             }
             else
             {


### PR DESCRIPTION
Closes https://github.com/UchuServer/Uchu/issues/195

There is a condition, which happens every time a player is killed by Maelstrom, where no coins are dropped when smashed because the coin owner is set to `null`. This change corrects the drop owner.