### PR TITLE
Fix Missions Requiring Active Missions

### DIFF
--- a/Uchu.World/Client/CdClient/MissionParser.cs
+++ b/Uchu.World/Client/CdClient/MissionParser.cs
@@ -22,7 +22,7 @@ namespace Uchu.World.Client
             };
         }
 
-        private static bool IsCompleted(string str, MissionInstance[] completed)
+        private static bool IsCompleted(string str, MissionInstance[] playerMissions)
         {
             if (string.IsNullOrWhiteSpace(str))
                 return true;
@@ -34,7 +34,7 @@ namespace Uchu.World.Client
                 var missionId = int.Parse(str.Substring(0, colonIndex));
                 var requiredState = int.Parse(str.Substring(colonIndex + 1));
 
-                var mission = completed.FirstOrDefault(m => m.MissionId == missionId);
+                var mission = playerMissions.FirstOrDefault(m => m.MissionId == missionId);
                 if (mission == default)
                     return false;
                 
@@ -42,10 +42,10 @@ namespace Uchu.World.Client
             }
             
             var id = int.Parse(str);
-            return completed.Any(c => c.MissionId == id);
+            return playerMissions.Any(c => c.MissionId == id);
         }
 
-        public static bool CheckPrerequiredMissions(string missions, MissionInstance[] completed)
+        public static bool CheckPrerequiredMissions(string missions, MissionInstance[] playerMissions)
         {
             if (string.IsNullOrWhiteSpace(missions))
                 return true;
@@ -70,7 +70,7 @@ namespace Uchu.World.Client
                     case '&':
                     case ',':
                     {
-                        res = Check(res, IsCompleted(cur.ToString(), completed), mode);
+                        res = Check(res, IsCompleted(cur.ToString(), playerMissions), mode);
 
                         cur.Clear();
 
@@ -83,7 +83,7 @@ namespace Uchu.World.Client
 
                     case '|':
                     {
-                        res = Check(res, IsCompleted(cur.ToString(), completed), mode);
+                        res = Check(res, IsCompleted(cur.ToString(), playerMissions), mode);
 
                         cur.Clear();
 
@@ -92,11 +92,11 @@ namespace Uchu.World.Client
                     }
 
                     case '(':
-                        res = Check(res, CheckPrerequiredMissions(missions.Substring(i + 1), completed), mode);
+                        res = Check(res, CheckPrerequiredMissions(missions.Substring(i + 1), playerMissions), mode);
                         break;
 
                     case ')':
-                        return Check(res, IsCompleted(cur.ToString(), completed), mode);
+                        return Check(res, IsCompleted(cur.ToString(), playerMissions), mode);
 
                     case '0':
                     case '1':
@@ -114,7 +114,7 @@ namespace Uchu.World.Client
                 }
             }
 
-            res = Check(res, IsCompleted(cur.ToString(), completed), mode);
+            res = Check(res, IsCompleted(cur.ToString(), playerMissions), mode);
 
             return res;
         }

--- a/Uchu.World/Objects/Components/Player/MissionInventoryComponent.cs
+++ b/Uchu.World/Objects/Components/Player/MissionInventoryComponent.cs
@@ -306,7 +306,7 @@ namespace Uchu.World
         /// <returns><c>true</c> if the player can accept this mission, <c>false</c> otherwise</returns>
         public bool CanAccept(MissionInstance mission) => 
             (mission.Repeatable || !HasMission(mission.MissionId)) 
-            && MissionParser.CheckPrerequiredMissions(mission.PrerequisiteMissions, CompletedMissions);
+            && MissionParser.CheckPrerequiredMissions(mission.PrerequisiteMissions, AllMissions);
         
         /// <summary>
         /// Checks if the player has a mission available that hasn't been started yet because of incorrect prerequisites.
@@ -315,7 +315,7 @@ namespace Uchu.World
         /// <param name="id">The mission id of the mission to check if the player has it available</param>
         /// <returns><c>true</c> if the player can accept this mission, <c>false</c> otherwise</returns>
         public bool HasAvailable(int id) => GetMission(id) is { } mission 
-                                            && MissionParser.CheckPrerequiredMissions(mission.PrerequisiteMissions, CompletedMissions);
+                                            && MissionParser.CheckPrerequiredMissions(mission.PrerequisiteMissions, AllMissions);
 
         /// <summary>
         /// Messages the client about a mission offer

--- a/Uchu.World/Objects/Components/Server/MissionGiverComponent.cs
+++ b/Uchu.World/Objects/Components/Server/MissionGiverComponent.cs
@@ -133,7 +133,7 @@ namespace Uchu.World
                     
                     if (!MissionParser.CheckPrerequiredMissions(
                         mission.PrereqMissionID,
-                        missionInventory.CompletedMissions))
+                        missionInventory.AllMissions))
                         continue;
 
                     // If this is a mission the player doesn't have yet or hasn't started yet, offer it

--- a/Uchu.World/Objects/Components/Server/MissionGiverComponent.cs
+++ b/Uchu.World/Objects/Components/Server/MissionGiverComponent.cs
@@ -112,6 +112,9 @@ namespace Uchu.World
                                 // Allow them to start it
                                 break;
                             case MissionState.Active:
+                                // Display the in-progress mission instead of possibly continuing and offering a new mission.
+                                missionInventory.MessageOfferMission(playerMission.MissionId, GameObject);
+                                return;
                             case MissionState.CompletedActive:
                                 // If this is an active mission show the offer popup again for information
                                 player.GetComponent<MissionInventoryComponent>().MessageOfferMission(

--- a/Uchu.World/Objects/Components/Server/MissionGiverComponent.cs
+++ b/Uchu.World/Objects/Components/Server/MissionGiverComponent.cs
@@ -82,6 +82,7 @@ namespace Uchu.World
 
             try
             {
+                int questIdToOffer = default;
                 foreach (var (mission, component) in Missions)
                 {
                     // Get the quest id.
@@ -136,10 +137,14 @@ namespace Uchu.World
                         missionInventory.AllMissions))
                         continue;
 
-                    // If this is a mission the player doesn't have yet or hasn't started yet, offer it
-                    missionInventory.MessageOfferMission(questId, GameObject);
-                    return;
+                    // Set the mission as the mission to offer.
+                    // The mission is not offered directly in cases where an Available mission comes up before a ReadyToComplete mission.
+                    questIdToOffer = questId;
                 }
+                
+                // Offer the mission. This happens if there are no completed missions to complete.
+                if (questIdToOffer == default) return;
+                missionInventory.MessageOfferMission(questIdToOffer, GameObject);
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Closes https://github.com/UchuServer/Uchu/issues/184
Closes https://github.com/UchuServer/Uchu/issues/172

This pull request fixes the problem of certain missions, such as The Ninja Masters and Yay for Spray, which requires 3 other missions to be completed, being unable to be started. This also fixes the design flaw where an available mission may be given if there is another active or complete mission if the mission giver stores the available mission before the others.

I tested this branch with the first 28 missions in Avant Gardens except for using `/complete` on the Avant Gardens survival mission. There is currently a bug where the achiever missions, the missions that require getting 10, then 20, then 30... missions/achievements, all complete together, but this isn't a problem introduced with this branch. See: https://github.com/UchuServer/Uchu/issues/198