### PR TITLE
Hide Inventory Models In World

### DIFF
--- a/Uchu.World/Objects/Components/Player/Concepts/Inventory.cs
+++ b/Uchu.World/Objects/Components/Player/Concepts/Inventory.cs
@@ -113,6 +113,7 @@ namespace Uchu.World
                 if (item != null)
                 {
                     Object.Start(item);
+                    item.Layer = StandardLayer.Hidden;
                 }
             });
             
@@ -129,6 +130,7 @@ namespace Uchu.World
             if (Items.Any(i => i.Slot == item.Slot))
                 throw new InventorySlotOccupiedException();
             _items.Add(item);
+            item.Layer = StandardLayer.Hidden;
         }
         
         /// <summary>


### PR DESCRIPTION
Closes https://github.com/UchuServer/Uchu/issues/193

This change makes it so inventory items, like models, are hidden in the world so that they aren't rendered at 0,0,0. Basic testing was done with an existing inventory as well as purchasing a new model and checking if it appeared at 0,0,0.