### PR TITLE
Make Corrupted Sentries Enemies

### DIFF
--- a/Uchu.StandardScripts/VentureExplorer/BrokenConsole.cs
+++ b/Uchu.StandardScripts/VentureExplorer/BrokenConsole.cs
@@ -9,6 +9,7 @@ namespace Uchu.StandardScripts.VentureExplorer
     ///     LUA Reference: l_ag_ship_player_shock_server.lua
     /// </summary>
     [ZoneSpecific(1000)]
+    [ZoneSpecific(1001)]
     public class BrokenConsole : NativeScript
     {
         private const string ScriptName = "l_ag_ship_player_shock_server.lua";

--- a/Uchu.StandardScripts/VentureExplorer/CorruptedSentry.cs
+++ b/Uchu.StandardScripts/VentureExplorer/CorruptedSentry.cs
@@ -1,0 +1,38 @@
+using System.Threading.Tasks;
+using Uchu.World;
+using Uchu.World.Scripting.Native;
+
+namespace Uchu.StandardScripts.VentureExplorer
+{
+    [ZoneSpecific(1001)]
+    public class CorruptedSentry : NativeScript
+    {
+        /// <summary>
+        /// Loads the script.
+        /// </summary>
+        public override Task LoadAsync()
+        {
+            foreach (var obj in Zone.Objects)
+            {
+                InitializeCorruptedSentry(obj);
+            }
+            Listen(Zone.OnObject,InitializeCorruptedSentry);
+            
+            return Task.CompletedTask;
+        }
+        
+        /// <summary>
+        /// Initializes the faction and enemies of the
+        /// corrupted sentry.
+        /// </summary>
+        /// <param name="obj"></param>
+        private void InitializeCorruptedSentry(Object obj)
+        {
+            if (!(obj is GameObject gameObject)) return;
+            if (gameObject.Lot != 8433) return;
+            if (!gameObject.TryGetComponent<DestroyableComponent>(out var destroyableComponent)) return;
+            destroyableComponent.Factions = new[] {4};
+            destroyableComponent.Enemies = new[] {1};
+        }
+    }
+}

--- a/Uchu.StandardScripts/VentureExplorer/CorruptedSentry.cs
+++ b/Uchu.StandardScripts/VentureExplorer/CorruptedSentry.cs
@@ -25,7 +25,7 @@ namespace Uchu.StandardScripts.VentureExplorer
         /// Initializes the faction and enemies of the
         /// corrupted sentry.
         /// </summary>
-        /// <param name="obj"></param>
+        /// <param name="obj">Corrupted sentry game object to initialize.</param>
         private void InitializeCorruptedSentry(Object obj)
         {
             if (!(obj is GameObject gameObject)) return;

--- a/Uchu.StandardScripts/VentureExplorer/CorruptedSentry.cs
+++ b/Uchu.StandardScripts/VentureExplorer/CorruptedSentry.cs
@@ -16,7 +16,7 @@ namespace Uchu.StandardScripts.VentureExplorer
             {
                 InitializeCorruptedSentry(obj);
             }
-            Listen(Zone.OnObject,InitializeCorruptedSentry);
+            Listen(Zone.OnObject, InitializeCorruptedSentry);
             
             return Task.CompletedTask;
         }

--- a/Uchu.World/Objects/Components/DestroyableComponent.cs
+++ b/Uchu.World/Objects/Components/DestroyableComponent.cs
@@ -324,6 +324,7 @@ namespace Uchu.World
             );
 
             if (stats == default) return;
+            HasStats = true;
 
             var rawHealth = stats.Life ?? 0;
             var rawArmor = (int) (stats.Armor ?? 0);
@@ -341,6 +342,7 @@ namespace Uchu.World
         private void CollectPlayerStats()
         {
             if (!(GameObject is Player)) return;
+            HasStats = true;
             
             using var ctx = new UchuContext();
 

--- a/Uchu.World/Objects/GameObjects/Player.cs
+++ b/Uchu.World/Objects/GameObjects/Player.cs
@@ -164,7 +164,6 @@ namespace Uchu.World
             AddComponent<PossessableOccupantComponent>();
             
             controllablePhysics.HasPosition = true;
-            stats.HasStats = true;
             
             // Server Components
             var inventoryManager = AddComponent<InventoryManagerComponent>();

--- a/Uchu.World/Scripting/Native/Attributes/ZoneSpecificAttribute.cs
+++ b/Uchu.World/Scripting/Native/Attributes/ZoneSpecificAttribute.cs
@@ -3,7 +3,7 @@ using Uchu.Core;
 
 namespace Uchu.World.Scripting.Native
 {
-    [AttributeUsage(AttributeTargets.Class)]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
     public class ZoneSpecificAttribute : Attribute
     {
         public readonly ZoneId ZoneId;

--- a/Uchu.World/Scripting/Native/NativeScriptPack.cs
+++ b/Uchu.World/Scripting/Native/NativeScriptPack.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
 using Uchu.Core;
+using Uchu.World.Scripting.Native;
 
 namespace Uchu.World.Scripting.Native
 {
@@ -32,11 +34,10 @@ namespace Uchu.World.Scripting.Native
             {
                 if (type.BaseType != typeof(NativeScript)) return;
 
-                var zoneSpecific = type.GetCustomAttribute<ZoneSpecificAttribute>();
-
-                if (zoneSpecific != null)
+                var zoneSpecific = type.GetCustomAttributes<ZoneSpecificAttribute>().ToArray();
+                if (zoneSpecific.Length > 0)
                 {
-                    if (zoneSpecific.ZoneId != Zone.ZoneId) continue;
+                    if (zoneSpecific.FirstOrDefault(zoneSpecificEntry => zoneSpecificEntry.ZoneId == Zone.ZoneId) == default) continue;
                 }
 
                 var instance = (NativeScript) Activator.CreateInstance(type);


### PR DESCRIPTION
Closes https://github.com/UchuServer/Uchu/issues/168

This pull request adds a script that corrects the "factions" and enemies of the Corrupted Sentries on Return to the Venture Explorer and corrects stats not being serialized and sent to clients, which also fixes health changes not being synced from non-player attacks. Also in this pull request is a fix for the broken console not knocking back the player since it is only set for zone 1000 instead of 1000 and 1001.