### PR TITLE
Improve configuration handling for ScriptDllSource

### DIFF
--- a/Uchu.Core/Config/UchuConfiguration.cs
+++ b/Uchu.Core/Config/UchuConfiguration.cs
@@ -150,10 +150,7 @@ namespace Uchu.Core.Config
         /// The path to the script source DLLs
         /// </summary>
         [XmlElement]
-        public List<string> ScriptDllSource { get; } = new List<string>
-        {
-            "Enter path to Uchu.StandardScripts.dll"
-        };
+        public List<string> ScriptDllSource { get; } = new List<string>();
     }
 
     /// <summary>

--- a/Uchu.Core/Config/UchuConfiguration.cs
+++ b/Uchu.Core/Config/UchuConfiguration.cs
@@ -144,13 +144,16 @@ namespace Uchu.Core.Config
         /// <summary>
         /// The path to the Uchu.Instance DLL
         /// </summary>
-        [XmlElement] public string Instance { get; set; } = "Uchu.Instance.dll";
+        [XmlElement] public string Instance { get; set; } = "Enter path to Uchu.Instance.dll";
         
         /// <summary>
         /// The path to the script source DLLs
         /// </summary>
         [XmlElement]
-        public List<string> ScriptDllSource { get; } = new List<string>();
+        public List<string> ScriptDllSource { get; } = new List<string>
+        {
+            "Enter path to Uchu.StandardScripts.dll"
+        };
     }
 
     /// <summary>

--- a/Uchu.Master/MasterServer.cs
+++ b/Uchu.Master/MasterServer.cs
@@ -267,14 +267,22 @@ namespace Uchu.Master
 
             if (!File.Exists(DllLocation))
             {
-                Logger.Error("Could not find file specified in DllSource -> Instance in config.xml.");
-                throw new FileNotFoundException("Could not find Instance file.");
+                throw new FileNotFoundException("Could not find file specified in <Instance> under <DllSource> in config.xml.");
             }
-            
-            if (Config.DllSource.ScriptDllSource.Count == 0)
+
+            var validScriptPackExists = Config.DllSource.ScriptDllSource.Exists(scriptPackPath =>
             {
-                Logger.Warning("No ScriptDllSource specified under DllSource in config.xml.\n" +
-                               "Without Uchu.StandardScripts.dll, Uchu will not function correctly.");
+                if (File.Exists(scriptPackPath))
+                    return true;
+
+                Logger.Warning($"Could not find script pack at {scriptPackPath}");
+                return false;
+            });
+
+            if (!validScriptPackExists)
+            {
+                throw new FileNotFoundException("No valid <ScriptDllSource> specified under <DllSource> in config.xml.\n"
+                                                + "Without Uchu.StandardScripts.dll, Uchu cannot function correctly.");
             }
             
             foreach (var scriptPackPath in Config.DllSource.ScriptDllSource)

--- a/Uchu.Master/MasterServer.cs
+++ b/Uchu.Master/MasterServer.cs
@@ -218,6 +218,8 @@ namespace Uchu.Master
             {
                 LogQueue.Config = Config = new UchuConfiguration();
 
+                Config.DllSource.ScriptDllSource.Add("Enter path to Uchu.StandardScripts.dll");
+
                 var backup = File.CreateText("config.default.xml");
 
                 serializer.Serialize(backup, Config);
@@ -268,8 +270,6 @@ namespace Uchu.Master
                 Logger.Error("Could not find file specified in DllSource -> Instance in config.xml.");
                 throw new FileNotFoundException("Could not find Instance file.");
             }
-
-            Config.DllSource.ScriptDllSource.RemoveAt(0);
             
             if (Config.DllSource.ScriptDllSource.Count == 0)
             {

--- a/Uchu.Master/MasterServer.cs
+++ b/Uchu.Master/MasterServer.cs
@@ -269,6 +269,12 @@ namespace Uchu.Master
                 throw new FileNotFoundException("Could not find Instance file.");
             }
 
+            if (Config.DllSource.ScriptDllSource.Count == 0)
+            {
+                Logger.Warning("No ScriptDllSource specified under DllSource in config.xml.\n" +
+                               "Without Uchu.StandardScripts.dll, Uchu will not function correctly.");
+            }
+            
             foreach (var scriptPackPath in Config.DllSource.ScriptDllSource)
             {
                 if (!File.Exists(scriptPackPath))

--- a/Uchu.Master/MasterServer.cs
+++ b/Uchu.Master/MasterServer.cs
@@ -269,6 +269,8 @@ namespace Uchu.Master
                 throw new FileNotFoundException("Could not find Instance file.");
             }
 
+            Config.DllSource.ScriptDllSource.RemoveAt(0);
+            
             if (Config.DllSource.ScriptDllSource.Count == 0)
             {
                 Logger.Warning("No ScriptDllSource specified under DllSource in config.xml.\n" +

--- a/Uchu.World/Scripting/ScriptManager.cs
+++ b/Uchu.World/Scripting/ScriptManager.cs
@@ -38,8 +38,6 @@ namespace Uchu.World.Scripting
             Logger.Information($"Loading native scripts...");
             
             var scriptPacks = new List<ScriptPack>();
-
-            Zone.UchuServer.Config.DllSource.ScriptDllSource.RemoveAt(0);
             
             foreach (var scriptPackPath in Zone.UchuServer.Config.DllSource.ScriptDllSource)
             {

--- a/Uchu.World/Scripting/ScriptManager.cs
+++ b/Uchu.World/Scripting/ScriptManager.cs
@@ -38,6 +38,8 @@ namespace Uchu.World.Scripting
             Logger.Information($"Loading native scripts...");
             
             var scriptPacks = new List<ScriptPack>();
+
+            Zone.UchuServer.Config.DllSource.ScriptDllSource.RemoveAt(0);
             
             foreach (var scriptPackPath in Zone.UchuServer.Config.DllSource.ScriptDllSource)
             {


### PR DESCRIPTION
- Add default value when generating config.default.xml
- Unlike previously, this default value is not attempted to load when another value is supplied in the config file
- Throw a descriptive error and quit if no valid script dll sources are configured at all