### PR TITLE
implment sentry error logging for packets, gms and events

### DIFF
--- a/Uchu.Core/Config/UchuConfiguration.cs
+++ b/Uchu.Core/Config/UchuConfiguration.cs
@@ -23,6 +23,12 @@ namespace Uchu.Core.Config
         };
 
         /// <summary>
+        /// Optional sentry DSN to use for tracking errors and exceptions
+        /// </summary>
+        [XmlElement]
+        public string SentryDsn { get; set; } = "";
+
+        /// <summary>
         /// The level of console logging (debug or production)
         /// </summary>
         [XmlElement]

--- a/Uchu.Core/Uchu.Core.csproj
+++ b/Uchu.Core/Uchu.Core.csproj
@@ -16,6 +16,7 @@
       <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.2.6" />
       <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="2.2.6" />
       <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="2.2.4" />
+      <PackageReference Include="Sentry" Version="3.0.6" />
       <PackageReference Include="StackExchange.Redis" Version="2.1.0-preview.23" />
     </ItemGroup>
 

--- a/Uchu.World/Handlers/GameMessages/SkillHandler.cs
+++ b/Uchu.World/Handlers/GameMessages/SkillHandler.cs
@@ -12,27 +12,13 @@ namespace Uchu.World.Handlers.GameMessages
         [PacketHandler]
         public async Task SkillStartHandler(StartSkillMessage message, Player player)
         {
-            try
-            {
-                await player.GetComponent<SkillComponent>().StartUserSkillAsync(message);
-            }
-            catch (Exception e)
-            {
-                Logger.Error(e);
-            }
+            await player.GetComponent<SkillComponent>().StartUserSkillAsync(message);
         }
 
         [PacketHandler]
         public async Task SyncSkillHandler(SyncSkillMessage message, Player player)
         {
-            try
-            {
                 player.GetComponent<SkillComponent>().SyncUserSkillAsync(message);
-            }
-            catch (Exception e)
-            {
-                Logger.Error(e);
-            }
         }
 
         [PacketHandler]

--- a/Uchu.World/Objects/Zone.cs
+++ b/Uchu.World/Objects/Zone.cs
@@ -12,6 +12,7 @@ using InfectedRose.Lvl;
 using InfectedRose.Utilities;
 using RakDotNet;
 using RakDotNet.IO;
+using Sentry;
 using Uchu.Core;
 using Uchu.Core.Client;
 using Uchu.Physics;
@@ -713,6 +714,7 @@ namespace Uchu.World
                 catch (Exception e)
                 {
                     Logger.Error(e);
+                    SentrySdk.CaptureException(e);
                 }
             }
             
@@ -750,7 +752,8 @@ namespace Uchu.World
                 }
                 catch (Exception e)
                 {
-                    Logger.Error(e.Message);
+                    Logger.Error(e);
+                    SentrySdk.CaptureException(e);
                 }
                 finally
                 {

--- a/Uchu.World/Systems/Behaviors/BehaviorTree.cs
+++ b/Uchu.World/Systems/Behaviors/BehaviorTree.cs
@@ -456,17 +456,10 @@ namespace Uchu.World.Systems.Behaviors
             if (!(Serialized || Deserialized))
                 throw new InvalidOperationException("Can't execute tree: it's neither serialized nor deserialized.");
 
-            try
-            {
-                ExecuteRootBehaviorsForSkillType(SkillCastType.Default);
-                
-                if (CastType != SkillCastType.Default)
-                    ExecuteRootBehaviorsForSkillType(CastType);
-            }
-            catch (Exception e)
-            {
-                Logger.Error($"Encountered error in tree execute: {e}");
-            }
+            ExecuteRootBehaviorsForSkillType(SkillCastType.Default);
+            
+            if (CastType != SkillCastType.Default)
+                ExecuteRootBehaviorsForSkillType(CastType);
         }
 
         /// <summary>
@@ -479,17 +472,10 @@ namespace Uchu.World.Systems.Behaviors
                 throw new InvalidOperationException("Can't use behavior: tree is not deserialized.");
             if (!RootBehaviors.TryGetValue(SkillCastType.OnUse, out var list))
                 return;
-
-            try
+         
+            foreach (var behaviorExecution in list)
             {
-                foreach (var behaviorExecution in list)
-                {
-                    behaviorExecution.BehaviorBase.ExecuteStart(behaviorExecution.BehaviorExecutionParameters);
-                }
-            }
-            catch (Exception e)
-            {
-                Logger.Error($"Encountered error during tree use: {e.Message}");
+                behaviorExecution.BehaviorBase.ExecuteStart(behaviorExecution.BehaviorExecutionParameters);
             }
         }
 
@@ -504,18 +490,11 @@ namespace Uchu.World.Systems.Behaviors
                 throw new InvalidOperationException("Can't mount tree: tree is not deserialized.");
             if (!RootBehaviors.TryGetValue(SkillCastType.OnEquip, out var list))
                 return;
-
-            try
+            
+            foreach (var executionPreparation in list)
             {
-                foreach (var executionPreparation in list)
-                {
-                    executionPreparation.BehaviorBase.ExecuteStart(executionPreparation
-                        .BehaviorExecutionParameters);
-                }
-            }
-            catch (Exception e)
-            {
-                Logger.Error($"Encountered error during tree mount: {e.Message}");
+                executionPreparation.BehaviorBase.ExecuteStart(executionPreparation
+                    .BehaviorExecutionParameters);
             }
         }
 
@@ -530,17 +509,10 @@ namespace Uchu.World.Systems.Behaviors
             if (!RootBehaviors.TryGetValue(SkillCastType.OnEquip, out var list)) 
                 return;
 
-            try
+            foreach (var executionPreparation in list)
             {
-                foreach (var executionPreparation in list)
-                {
-                    executionPreparation.BehaviorBase.Dismantle(executionPreparation
-                        .BehaviorExecutionParameters);
-                }
-            }
-            catch (Exception e)
-            {
-                Logger.Error($"Encountered error during tree dismantle: {e.Message}");
+                executionPreparation.BehaviorBase.Dismantle(executionPreparation
+                    .BehaviorExecutionParameters);
             }
         }
     }

--- a/Uchu.World/Uchu.World.csproj
+++ b/Uchu.World/Uchu.World.csproj
@@ -22,4 +22,8 @@
       <Folder Include="Systems" />
     </ItemGroup>
 
+    <ItemGroup>
+      <PackageReference Include="Sentry" Version="3.0.6" />
+    </ItemGroup>
+
 </Project>

--- a/Uchu.World/Utilities/Event.cs
+++ b/Uchu.World/Utilities/Event.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using Sentry;
 using Uchu.Core;
 
 namespace Uchu.World
@@ -72,6 +73,7 @@ namespace Uchu.World
                 catch (Exception e)
                 {
                     Logger.Error(e);
+                    SentrySdk.CaptureException(e);
                 }
             }
 
@@ -84,6 +86,7 @@ namespace Uchu.World
                 catch (Exception e)
                 {
                     Logger.Error(e);
+                    SentrySdk.CaptureException(e);
                 }
             }
         }
@@ -100,6 +103,7 @@ namespace Uchu.World
                 }
                 catch (Exception e)
                 {
+                    SentrySdk.CaptureException(e);
                     Logger.Error(e);
                 }
             }
@@ -112,6 +116,7 @@ namespace Uchu.World
                 }
                 catch (Exception e)
                 {
+                    SentrySdk.CaptureException(e);
                     Logger.Error(e);
                 }
             }
@@ -134,6 +139,7 @@ namespace Uchu.World
                 catch (Exception e)
                 {
                     Logger.Error(e);
+                    SentrySdk.CaptureException(e);
                 }
             }
 
@@ -146,6 +152,7 @@ namespace Uchu.World
                 catch (Exception e)
                 {
                     Logger.Error(e);
+                    SentrySdk.CaptureException(e);
                 }
             }
         }
@@ -163,6 +170,7 @@ namespace Uchu.World
                 catch (Exception e)
                 {
                     Logger.Error(e);
+                    SentrySdk.CaptureException(e);
                 }
             }
 
@@ -175,6 +183,7 @@ namespace Uchu.World
                 catch (Exception e)
                 {
                     Logger.Error(e);
+                    SentrySdk.CaptureException(e);
                 }
             }
         }
@@ -196,6 +205,7 @@ namespace Uchu.World
                 catch (Exception e)
                 {
                     Logger.Error(e);
+                    SentrySdk.CaptureException(e);
                 }
             }
 
@@ -208,6 +218,7 @@ namespace Uchu.World
                 catch (Exception e)
                 {
                     Logger.Error(e);
+                    SentrySdk.CaptureException(e);
                 }
             }
         }
@@ -225,6 +236,7 @@ namespace Uchu.World
                 catch (Exception e)
                 {
                     Logger.Error(e);
+                    SentrySdk.CaptureException(e);
                 }
             }
 
@@ -237,6 +249,7 @@ namespace Uchu.World
                 catch (Exception e)
                 {
                     Logger.Error(e);
+                    SentrySdk.CaptureException(e);
                 }
             }
         }
@@ -258,6 +271,7 @@ namespace Uchu.World
                 catch (Exception e)
                 {
                     Logger.Error(e);
+                    SentrySdk.CaptureException(e);
                 }
             }
 
@@ -270,6 +284,7 @@ namespace Uchu.World
                 catch (Exception e)
                 {
                     Logger.Error(e);
+                    SentrySdk.CaptureException(e);
                 }
             }
         }
@@ -287,6 +302,7 @@ namespace Uchu.World
                 catch (Exception e)
                 {
                     Logger.Error(e);
+                    SentrySdk.CaptureException(e);
                 }
             }
 
@@ -299,6 +315,7 @@ namespace Uchu.World
                 catch (Exception e)
                 {
                     Logger.Error(e);
+                    SentrySdk.CaptureException(e);
                 }
             }
         }

--- a/Uchu.World/WorldUchuServer.cs
+++ b/Uchu.World/WorldUchuServer.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Threading.Tasks;
 using RakDotNet;
 using RakDotNet.IO;
+using Sentry;
 using Uchu.Api.Models;
 using Uchu.Core;
 using Uchu.Python;
@@ -44,15 +45,13 @@ namespace Uchu.World
         public override async Task ConfigureAsync(string configFile)
         {
             Logger.Information($"Created WorldServer on PID {Process.GetCurrentProcess().Id.ToString()}");
-
             await base.ConfigureAsync(configFile);
-            
+
             ZoneParser = new ZoneParser(Resources);
-            
             Whitelist = new Whitelist(Resources);
-            
+
             await Whitelist.LoadDefaultWhitelist();
-            
+
             GameMessageReceived += HandleGameMessageAsync;
             ServerStopped += () =>
             {
@@ -67,11 +66,11 @@ namespace Uchu.World
             ).ConfigureAwait(false);
 
             ZoneId = (ZoneId) instance.Info.Zones.First();
-            
+
             var info = await Api.RunCommandAsync<InstanceInfoResponse>(MasterApi, $"instance/target?i={Id}");
 
             Api.RegisterCommandCollection<WorldCommands>(this);
-            
+
             ManagedScriptEngine.AdditionalPaths = Config.ManagedScriptSources.Paths.ToArray();
 
             _ = Task.Run(async () =>
@@ -79,7 +78,7 @@ namespace Uchu.World
                 Logger.Information("Loading CDClient cache");
                 await ClientCache.LoadAsync();
             });
-            
+
             _ = Task.Run(async () =>
             {
                 Logger.Information($"Setting up zones for world server {Id}");


### PR DESCRIPTION
Allows the user to specify a sentry DSN (see: https://sentry.io/) to which exception logging is sent. This does not affect performance as these requests are sent in the background. If no sentry DSN is provided calls to sentry logging are no-ops. I've been testing this on my test server over the last two days and has performed great.