### PR TITLE
Resolve NullReferenceException when exiting in the build arranger

### DIFF
--- a/Uchu.World/Objects/Components/Player/ModularBuilderComponent.cs
+++ b/Uchu.World/Objects/Components/Player/ModularBuilderComponent.cs
@@ -132,10 +132,9 @@ namespace Uchu.World
                 return;
 
             var inventory = GameObject.GetComponent<InventoryManagerComponent>();
-            
-                foreach (var temp in inventory[InventoryType.TemporaryModels].Items)
-                if (temp.Count < 0) ; // Make sure we account for builds where no parts were used
-                else
+            if (inventory[InventoryType.TemporaryModels] != null)
+            {
+            foreach (var temp in inventory[InventoryType.TemporaryModels].Items)
                 {
                     await inventory.MoveItemBetweenInventoriesAsync(
                         temp,
@@ -144,6 +143,7 @@ namespace Uchu.World
                         InventoryType.Models
                     );
                 }
+            }
             
             var thinkingHat = inventory[InventoryType.Items].Items.First(i => i.Lot == 6086);
             await thinkingHat.UnEquipAsync();

--- a/Uchu.World/Objects/Components/Player/ModularBuilderComponent.cs
+++ b/Uchu.World/Objects/Components/Player/ModularBuilderComponent.cs
@@ -134,7 +134,7 @@ namespace Uchu.World
             var inventory = GameObject.GetComponent<InventoryManagerComponent>();
             if (inventory[InventoryType.TemporaryModels] != null)
             {
-		foreach (var temp in inventory[InventoryType.TemporaryModels].Items)
+                foreach (var temp in inventory[InventoryType.TemporaryModels].Items)
                 {
                     await inventory.MoveItemBetweenInventoriesAsync(
                         temp,

--- a/Uchu.World/Objects/Components/Player/ModularBuilderComponent.cs
+++ b/Uchu.World/Objects/Components/Player/ModularBuilderComponent.cs
@@ -133,15 +133,17 @@ namespace Uchu.World
 
             var inventory = GameObject.GetComponent<InventoryManagerComponent>();
             
-            foreach (var temp in inventory[InventoryType.TemporaryModels].Items)
-            {
-                await inventory.MoveItemBetweenInventoriesAsync(
-                    temp,
-                    temp.Count,
-                    InventoryType.TemporaryModels,
-                    InventoryType.Models
-                );
-            }
+                foreach (var temp in inventory[InventoryType.TemporaryModels].Items)
+                if (temp.Count < 0) ; // Make sure we account for builds where no parts were used
+                else
+                {
+                    await inventory.MoveItemBetweenInventoriesAsync(
+                        temp,
+                        temp.Count,
+                        InventoryType.TemporaryModels,
+                        InventoryType.Models
+                    );
+                }
             
             var thinkingHat = inventory[InventoryType.Items].Items.First(i => i.Lot == 6086);
             await thinkingHat.UnEquipAsync();

--- a/Uchu.World/Objects/Components/Player/ModularBuilderComponent.cs
+++ b/Uchu.World/Objects/Components/Player/ModularBuilderComponent.cs
@@ -134,7 +134,7 @@ namespace Uchu.World
             var inventory = GameObject.GetComponent<InventoryManagerComponent>();
             if (inventory[InventoryType.TemporaryModels] != null)
             {
-				foreach (var temp in inventory[InventoryType.TemporaryModels].Items)
+		foreach (var temp in inventory[InventoryType.TemporaryModels].Items)
                 {
                     await inventory.MoveItemBetweenInventoriesAsync(
                         temp,

--- a/Uchu.World/Objects/Components/Player/ModularBuilderComponent.cs
+++ b/Uchu.World/Objects/Components/Player/ModularBuilderComponent.cs
@@ -134,7 +134,7 @@ namespace Uchu.World
             var inventory = GameObject.GetComponent<InventoryManagerComponent>();
             if (inventory[InventoryType.TemporaryModels] != null)
             {
-            foreach (var temp in inventory[InventoryType.TemporaryModels].Items)
+				foreach (var temp in inventory[InventoryType.TemporaryModels].Items)
                 {
                     await inventory.MoveItemBetweenInventoriesAsync(
                         temp,


### PR DESCRIPTION
This pull request adds a separate task to handle players exiting the build arranger without actually completing the build. The current implementation of using ConfirmFinish() when exiting the build arranger mode will produce a NullReferenceException when you exit without completing the build, which also causes some noticeable side effects. The Thinking Hat will not get removed properly when this exception happens, allowing your character to walk around wearing it when they are not even in a building environment (which also stops your character from attacking). This is fixed with this PR.

I've been testing these changes for a bit on my local install and nothing seemed to break. However, I'd like to hear thoughts on this and if anything can be improved!