### PR TITLE
Add Player Leave Event

### DIFF
--- a/Uchu.Char/Handlers/CharacterHandler.cs
+++ b/Uchu.Char/Handlers/CharacterHandler.cs
@@ -6,6 +6,7 @@ using Microsoft.EntityFrameworkCore;
 using RakDotNet;
 using Uchu.Core;
 using Uchu.Core.Client;
+using Uchu.World;
 
 namespace Uchu.Char.Handlers
 {
@@ -69,7 +70,17 @@ namespace Uchu.Char.Handlers
         [PacketHandler]
         public async Task CharacterList(CharacterListRequest packet, IRakConnection connection)
         {
+            // Remove the player from the zone.
             var session = UchuServer.SessionCache.GetSession(connection.EndPoint);
+            if (UchuServer is WorldUchuServer worldUchuServer) {
+                var player = worldUchuServer.FindPlayer(connection);
+                if (player != null)
+                {
+                    await player.DestroyAsync();
+                }
+            }
+            
+            // Send the character list.
             await SendCharacterList(connection, session.UserId);
         }
 

--- a/Uchu.Char/Uchu.Char.csproj
+++ b/Uchu.Char/Uchu.Char.csproj
@@ -7,6 +7,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\Uchu.Core\Uchu.Core.csproj" />
+      <ProjectReference Include="..\Uchu.World\Uchu.World.csproj" />
     </ItemGroup>
 
 </Project>

--- a/Uchu.World/Objects/GameObjects/Player.cs
+++ b/Uchu.World/Objects/GameObjects/Player.cs
@@ -53,10 +53,7 @@ namespace Uchu.World
             {
                 Connection.Disconnected += async reason =>
                 {
-                    Logger.Information($"{this} left: {reason}.");
-                    await GetComponent<SaveComponent>().SaveAsync(false);
-                    Connection = default;
-                    Destroy(this);
+                    await DestroyAsync();
                 };
 
                 Listen(OnPositionUpdate, UpdatePhysics);
@@ -115,6 +112,17 @@ namespace Uchu.World
                 OnWorldLoad.Clear();
                 OnPositionUpdate.Clear();
             });
+        }
+
+        /// <summary>
+        /// Destroys the player.
+        /// </summary>
+        public async Task DestroyAsync(CloseReason? reason = CloseReason.ClientDisconnect)
+        {
+            Logger.Information($"{this} left: {reason}.");
+            await GetComponent<SaveComponent>().SaveAsync(false);
+            Connection = default;
+            Destroy(this);
         }
 
         /// <summary>

--- a/Uchu.World/Objects/Zone.cs
+++ b/Uchu.World/Objects/Zone.cs
@@ -83,6 +83,7 @@ namespace Uchu.World
         
         // Events
         public Event<Player> OnPlayerLoad { get; }
+        public Event<Player> OnPlayerLeave { get; }
         public Event<Object> OnObject { get; }
         public Event OnTick { get; }
         public Event<Player, string> OnChatMessage { get; }
@@ -98,6 +99,7 @@ namespace Uchu.World
             EarlyPhysics = new Event();
             LatePhysics = new Event();
             OnPlayerLoad = new Event<Player>();
+            OnPlayerLeave = new Event<Player>();
             OnObject = new Event<Object>();
             OnTick = new Event();
             OnChatMessage = new Event<Player, string>();
@@ -400,6 +402,12 @@ namespace Uchu.World
                 if (!ManagedObjects.Contains(obj)) return;
                 
                 ManagedObjects.Remove(obj);
+
+                // Invoke the player left event if the object is an event.
+                if (obj is Player player)
+                {
+                    OnPlayerLeave.Invoke(player);
+                }
 
                 if (obj is GameObject gameObject)
                 {


### PR DESCRIPTION
This pull request adds an event that can be connected to players leaving the zone, which will help development in `enhancement/minigame-provisioning`. There is also a change where the zone's player is destroyed when the character list is requested so that the player no longer interacts with the zone. Quick demo:

https://user-images.githubusercontent.com/13441476/108928942-109a4780-7611-11eb-9554-82bd75388b86.mp4

