### PR TITLE
Fix Player Loading Being Blocked

### DIFF
--- a/Uchu.World/Handlers/GameMessages/ModularBuildingHandler.cs
+++ b/Uchu.World/Handlers/GameMessages/ModularBuildingHandler.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Uchu.Core;
@@ -43,15 +44,10 @@ namespace Uchu.World.Handlers.GameMessages
         }
 
         [PacketHandler]
-        public async Task SetLastCustomBuildHandler(SetLastCustomBuildMessage message, Player player)
+        public void SetLastCustomBuildHandler(SetLastCustomBuildMessage message, Player player)
         {
-            await using var ctx = new UchuContext();
-
-            var character = await ctx.Characters.FirstAsync(c => c.Id == player.Id);
-
-            character.Rocket = message.Tokens;
-
-            await ctx.SaveChangesAsync();
+            if (!player.TryGetComponent<CharacterComponent>(out var characterComponent));
+            characterComponent.Rocket = message.Tokens;
         }
 
         [PacketHandler]

--- a/Uchu.World/Objects/Components/ReplicaComponents/CharacterComponent.cs
+++ b/Uchu.World/Objects/Components/ReplicaComponents/CharacterComponent.cs
@@ -211,7 +211,7 @@ namespace Uchu.World
         public int InventorySize { get; set; }
         public int BaseImagination { get; set; }
         public int BaseHealth { get; set; }
-        public string Rocket { get; private set; }
+        public string Rocket { get; set; }
         public int LaunchedRocketFrom { get; set; }
         public long LastActivity { get; private set; }
         public bool FreeToPlay { get; private set; }
@@ -575,14 +575,22 @@ namespace Uchu.World
             writer.Write((ulong) TotalFirstPlaceFinishes);
             writer.WriteBit(false);
 
-            writer.WriteBit(LandingByRocket);
-
-            if (LandingByRocket)
+            if (Rocket != default)
             {
-                var rocketString = Rocket;
-                
-                writer.Write((ushort) rocketString.Length);
-                writer.WriteString(rocketString, rocketString.Length, true);
+                // Send the rocket if it is set to land by rocket and rocket is defined.
+                writer.WriteBit(LandingByRocket);
+
+                if (LandingByRocket)
+                {
+                    var rocketString = Rocket;
+                    writer.Write((ushort) rocketString.Length);
+                    writer.WriteString(rocketString, rocketString.Length, true);
+                }
+            }
+            else
+            {
+                // Set the landing as not by rocket. Even if it is, this prevents a null reference exception.
+                writer.WriteBit(false);
             }
 
             WritePart4(writer);

--- a/Uchu.World/Objects/Components/Server/RocketLaunchpadComponent.cs
+++ b/Uchu.World/Objects/Components/Server/RocketLaunchpadComponent.cs
@@ -12,14 +12,11 @@ namespace Uchu.World
         {
             Listen(OnStart, () =>
             {
-                Listen(GameObject.OnInteract, async player =>
-                {
-                    await OnInteract(player);
-                });
+                Listen(GameObject.OnInteract, OnInteract);
             });
         }
 
-        public async Task OnInteract(Player player)
+        public void OnInteract(Player player)
         {
             var rocket = player.GetComponent<InventoryManagerComponent>()[InventoryType.Models].Items.FirstOrDefault(
                 item => item.Lot == Lot.ModularRocket
@@ -28,7 +25,6 @@ namespace Uchu.World
             if (rocket == default)
             {
                 Logger.Error($"Could not find a valid rocket for {player}");
-                
                 return;
             }
 
@@ -42,13 +38,8 @@ namespace Uchu.World
                 Sender = player
             });
 
-            await using var ctx = new UchuContext();
-
-            var character = await ctx.Characters.FirstAsync(c => c.Id == player.Id);
-
-            character.LandingByRocket = true;
-            
-            await ctx.SaveChangesAsync();
+            if (!player.TryGetComponent<CharacterComponent>(out var characterComponent));
+            characterComponent.LandingByRocket = true;
         }
     }
 }

--- a/Uchu.World/Objects/GameObjects/Player.cs
+++ b/Uchu.World/Objects/GameObjects/Player.cs
@@ -24,6 +24,15 @@ namespace Uchu.World
     {
         public static async Task<Player> Instantiate(IRakConnection connection, Zone zone, ObjectId id)
         {
+            // Set up a cancellation token for the connection disconnecting.
+            // This may happen before the object starts.
+            var cancellationToken = new CancellationTokenSource();
+            connection.Disconnected += (disconnectionReason) =>
+            {
+                cancellationToken.Cancel();
+                return Task.CompletedTask;
+            };
+            
             // Create base game object
             var instance = Instantiate<Player>(
                 zone,
@@ -34,7 +43,7 @@ namespace Uchu.World
                 lot: 1
             );
 
-            await instance.LoadAsync(connection);
+            await instance.LoadAsync(connection, cancellationToken.Token);
             return instance;
         }
         
@@ -51,6 +60,13 @@ namespace Uchu.World
 
             Listen(OnStart, () =>
             {
+                // Destroy the player on disconnect.
+                // Also check if the player disconnected during loading.
+                if (_loadCancellationToken != default && _loadCancellationToken.IsCancellationRequested)
+                {
+                    DestroyAsync().Wait();
+                    return;
+                }
                 Connection.Disconnected += async reason =>
                 {
                     await DestroyAsync();
@@ -132,7 +148,7 @@ namespace Uchu.World
         /// <param name="connection">User endpoint for this character</param>
         /// <param name="zone">The zone to spawn in</param>
         /// <returns>The constructed player</returns>
-        public async Task LoadAsync(IRakConnection connection)
+        public async Task LoadAsync(IRakConnection connection, CancellationToken cancellationToken)
         {
             await using var uchuContext = new UchuContext();
             var character = await uchuContext.Characters
@@ -140,6 +156,7 @@ namespace Uchu.World
 
             Connection = connection;
             Name = character.Name;
+            _loadCancellationToken = cancellationToken;
 
             // Setup layers
             Layer = StandardLayer.Player;
@@ -253,6 +270,12 @@ namespace Uchu.World
         /// Internal gravity scale of the player
         /// </summary>
         private float _gravityScale = 1;
+
+        /// <summary>
+        /// Cancellation token for loading the player, such
+        /// as if the player disconnects.
+        /// </summary>
+        private CancellationToken _loadCancellationToken;
         
         /// <summary>
         /// Gravity scale of the player

--- a/Uchu.World/Objects/ReplicaManager/ConstructionPacket.cs
+++ b/Uchu.World/Objects/ReplicaManager/ConstructionPacket.cs
@@ -1,0 +1,32 @@
+using RakDotNet;
+using RakDotNet.IO;
+
+namespace Uchu.World.Objects.ReplicaManager
+{
+    public class ConstructionPacket : ISerializable
+    {
+        /// <summary>
+        /// Id to serialize with.
+        /// </summary>
+        public ushort Id { get; set; }
+
+        /// <summary>
+        /// Game object to construct.
+        /// </summary>
+        public GameObject GameObject { get; set; }
+        
+        /// <summary>
+        /// Writes the serialization data.
+        /// </summary>
+        /// <param name="writer">Bit writer for the data.</param>
+        public void Serialize(BitWriter writer)
+        {
+            writer.Write((byte) MessageIdentifier.ReplicaManagerConstruction);
+
+            writer.WriteBit(true);
+            writer.Write(Id);
+
+            GameObject.WriteConstruct(writer);
+        }
+    }
+}

--- a/Uchu.World/Objects/ReplicaManager/DestructionPacket.cs
+++ b/Uchu.World/Objects/ReplicaManager/DestructionPacket.cs
@@ -1,0 +1,24 @@
+using RakDotNet;
+using RakDotNet.IO;
+
+namespace Uchu.World.Objects.ReplicaManager
+{
+    public class DestructionPacket: ISerializable
+    {
+        /// <summary>
+        /// Id to serialize with.
+        /// </summary>
+        public ushort Id { get; set; }
+        
+        /// <summary>
+        /// Writes the serialization data.
+        /// </summary>
+        /// <param name="writer">Bit writer for the data.</param>
+        public void Serialize(BitWriter writer)
+        {
+            writer.Write((byte) MessageIdentifier.ReplicaManagerDestruction);
+
+            writer.Write(Id);
+        }
+    }
+}

--- a/Uchu.World/Objects/ReplicaManager/SerializePacket.cs
+++ b/Uchu.World/Objects/ReplicaManager/SerializePacket.cs
@@ -1,0 +1,31 @@
+using RakDotNet;
+using RakDotNet.IO;
+
+namespace Uchu.World.Objects.ReplicaManager
+{
+    public class SerializePacket : ISerializable
+    {
+        /// <summary>
+        /// Id to serialize with.
+        /// </summary>
+        public ushort Id { get; set; }
+
+        /// <summary>
+        /// Game object to construct.
+        /// </summary>
+        public GameObject GameObject { get; set; }
+        
+        /// <summary>
+        /// Writes the serialization data.
+        /// </summary>
+        /// <param name="writer">Bit writer for the data.</param>
+        public void Serialize(BitWriter writer)
+        {
+            writer.Write((byte) MessageIdentifier.ReplicaManagerSerialize);
+
+            writer.Write(Id);
+
+            GameObject.WriteSerialize(writer);
+        }
+    }
+}


### PR DESCRIPTION
Closes https://github.com/UchuServer/Uchu/issues/67

This pull request *attempts* to fix the loading getting stuck at 55%. The problem is caused by a race condition where the player disconnects before the player instantiation completes, which results in the disconnection event never firing. This results in players being in the world when they are disconnected. This eventually leads to the problem of other players because of object Construction, Serialization, and Destruction, throwing exceptions due to being unable to send data to the disconnected player, which stops the player connection handling.

The fix involves making it so an exception doesn't stop the replication of packets. There are 2 methods that do this currently, but only 1 catches exceptions, which works by using `ISerializable` objects, and the other doesn't. The other one is used, so moving to `ISerializable` components fixes this, and makes the code a bit less repetitive with the copy-and-pasted creation of streams.

This also fixes the launchpads not showing rockets on landing, which was initially thought to be in the same code but isn't actually.