### PR TITLE
Improve logging for smaller console windows

### DIFF
--- a/Uchu.Core/Config/UchuConfiguration.cs
+++ b/Uchu.Core/Config/UchuConfiguration.cs
@@ -200,10 +200,20 @@ namespace Uchu.Core.Config
         [XmlElement] public int MaxWorldServers { get; set; } = 100;
 
         /// <summary>
-        /// The amount of heart beats the server should send per minute for it to retain it's healthy status for the
-        /// master server
+        /// The amount of heart beats the server should send per heart beat interval for it to retain it's healthy
+        /// status for the master server
         /// </summary>
-        [XmlElement] public int WorldServerHeartbeatsPerMinute { get; set; } = 4;
+        [XmlElement] public int WorldServerHeartBeatsPerInterval { get; set; } = 10;
+
+        /// <summary>
+        /// The interval over which heart beats should be received in minutes
+        /// </summary>
+        /// <remarks>
+        /// Note that this also corresponds to the max loading time for a world before the master server shuts it down.
+        /// As a world server is started in the healthy phase with no heart beats it takes 5 times this amount for the
+        /// world server to be shut down.
+        /// </remarks>
+        [XmlElement] public int WorldServerHeartBeatIntervalInMinutes { get; set; } = 5;
         
         /// <summary>
         /// The ports to run the world servers at

--- a/Uchu.Core/Config/UchuConfiguration.cs
+++ b/Uchu.Core/Config/UchuConfiguration.cs
@@ -198,6 +198,12 @@ namespace Uchu.Core.Config
         /// The maximum amount of world servers that may be generated
         /// </summary>
         [XmlElement] public int MaxWorldServers { get; set; } = 100;
+
+        /// <summary>
+        /// The amount of heart beats the server should send per minute for it to retain it's healthy status for the
+        /// master server
+        /// </summary>
+        [XmlElement] public int WorldServerHeartbeatsPerMinute { get; set; } = 4;
         
         /// <summary>
         /// The ports to run the world servers at

--- a/Uchu.Core/UchuServer.cs
+++ b/Uchu.Core/UchuServer.cs
@@ -121,6 +121,12 @@ namespace Uchu.Core
         /// Optional certificate for SSL
         /// </summary>
         protected X509Certificate Certificate { get; set; }
+        
+        /// <summary>
+        /// The amount of heart beats the world server should send to the master server to retain its healthy status. If
+        /// the world server can't keep up with this amount it risks being killed by the master server
+        /// </summary>
+        public int HeartBeatsPerMinute { get; set; }
 
         /// <summary>
         /// The host on which the server is running, used for example for API callbacks
@@ -227,6 +233,8 @@ namespace Uchu.Core
                 Logger.Information("Caching service is disabled, falling back to database.");
                 SessionCache = new DatabaseCache();
             }
+
+            HeartBeatsPerMinute = Config.Networking.WorldServerHeartbeatsPerMinute;
 
             Logger.Information($"Server {Id} configured on port: {Port}");
         }

--- a/Uchu.Core/UchuServer.cs
+++ b/Uchu.Core/UchuServer.cs
@@ -126,7 +126,22 @@ namespace Uchu.Core
         /// The amount of heart beats the world server should send to the master server to retain its healthy status. If
         /// the world server can't keep up with this amount it risks being killed by the master server
         /// </summary>
-        public int HeartBeatsPerMinute { get; set; }
+        public int HeartBeatsPerInterval { get; set; }
+        
+        /// <summary>
+        /// The total time in which <see cref="HeartBeatsPerInterval"/> heart beats should have been sent to retain the
+        /// healthy status
+        /// </summary>
+        public int HeartBeatIntervalInMinutes { get; set; }
+        
+        /// <summary>
+        /// The interval in milliseconds at which heart beats should be sent
+        /// </summary>
+        /// <remarks>
+        /// Returns essentially one heart beat more than absolutely necessary for a healthy status to ensure that small
+        /// hick ups and lag do not interfere with overall server health 
+        /// </remarks>
+        public float HeartBeatInterval => (float) HeartBeatIntervalInMinutes * 60000 / (HeartBeatsPerInterval + 1);
 
         /// <summary>
         /// The host on which the server is running, used for example for API callbacks
@@ -234,7 +249,8 @@ namespace Uchu.Core
                 SessionCache = new DatabaseCache();
             }
 
-            HeartBeatsPerMinute = Config.Networking.WorldServerHeartbeatsPerMinute;
+            HeartBeatsPerInterval = Config.Networking.WorldServerHeartBeatsPerInterval;
+            HeartBeatIntervalInMinutes = Config.Networking.WorldServerHeartBeatIntervalInMinutes;
 
             Logger.Information($"Server {Id} configured on port: {Port}");
         }

--- a/Uchu.Master/Api/MasterCommands.cs
+++ b/Uchu.Master/Api/MasterCommands.cs
@@ -87,6 +87,8 @@ namespace Uchu.Master.Api
         {
             var response = new BaseResponse();
             
+            Logger.Information("Received heart beat");
+            
             if ((await MasterServer.GetAllInstancesAsync()).FirstOrDefault() is {} instance
                 && MasterServer.InstanceHeartBeats.ContainsKey(id))
             {

--- a/Uchu.Master/MasterServer.cs
+++ b/Uchu.Master/MasterServer.cs
@@ -44,7 +44,8 @@ namespace Uchu.Master
         
         public static ApiManager Api { get; set; }
         
-        public static int WorldServerHeartBeatsPerMinute { get; set; }
+        public static int WorldServerHeartBeatsIntervalInMinutes { get; set; }
+        public static int WorldServerHeartBeatsPerInterval { get; set; }
 
         public static int MasterPort => Config.ApiConfig.Port;
         
@@ -89,7 +90,7 @@ namespace Uchu.Master
             await SetupApiAsync();
             
             // Setup health checks and automatic server closing
-            InstanceHeartBeatCheck = new Timer(60000);
+            InstanceHeartBeatCheck = new Timer(WorldServerHeartBeatsIntervalInMinutes * 60000);
             InstanceHeartBeatCheck.Elapsed += async (sender, eventArgs) =>
             {
                 foreach (var instance in Instances.Where(i => i.ServerType == ServerType.World).ToList())
@@ -98,7 +99,7 @@ namespace Uchu.Master
                     if (InstanceHealth.ContainsKey(id) && InstanceHeartBeats.ContainsKey(id))
                     {
                         InstanceHealth[id] = (InstanceHeartBeats[id] != 0 
-                                ? (float) InstanceHeartBeats[id] / WorldServerHeartBeatsPerMinute : 0) switch
+                                ? (float) InstanceHeartBeats[id] / WorldServerHeartBeatsPerInterval : 0) switch
                         {
                             var health when health >= 1 => ServerHealth.Healthy,
                             var health when health >= 0.75 => ServerHealth.Lagging,
@@ -345,7 +346,8 @@ namespace Uchu.Master
             }
 
             ApiPortIndex = Config.ApiConfig.Port;
-            WorldServerHeartBeatsPerMinute = Config.Networking.WorldServerHeartbeatsPerMinute;
+            WorldServerHeartBeatsPerInterval = Config.Networking.WorldServerHeartBeatsPerInterval;
+            WorldServerHeartBeatsIntervalInMinutes = Config.Networking.WorldServerHeartBeatIntervalInMinutes;
 
             var source = Directory.GetCurrentDirectory();
             

--- a/Uchu.Master/MasterServer.cs
+++ b/Uchu.Master/MasterServer.cs
@@ -416,12 +416,12 @@ namespace Uchu.Master
                     subsidiary, "instance/list"
                 );
                 
-                if (result == default) continue;
+                if (result == null)
+                    continue;
 
                 if (!result.Success)
                 {
                     Logger.Error(result.FailedReason);
-                    
                     continue;
                 }
 

--- a/Uchu.Master/MasterServer.cs
+++ b/Uchu.Master/MasterServer.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
+using System.Timers;
 using System.Xml.Serialization;
 using Uchu.Api;
 using Uchu.Api.Models;
@@ -21,7 +22,10 @@ namespace Uchu.Master
         public static UchuConfiguration Config { get; set; }
 
         public static List<ServerInstance> Instances { get; set; }
-        
+
+        public static Dictionary<string, int> InstanceHeartBeats { get; set; }
+        public static Dictionary<string, ServerHealth> InstanceHealth { get; set; }
+        public static Timer InstanceHeartBeatCheck { get; set; }  
         public static string ConfigPath { get; set; }
         
         public static string CdClientPath { get; set; }
@@ -39,17 +43,20 @@ namespace Uchu.Master
         public static List<int> Subsidiaries { get; set; }
         
         public static ApiManager Api { get; set; }
+        
+        public static int WorldServerHeartBeatsPerMinute { get; set; }
 
         public static int MasterPort => Config.ApiConfig.Port;
         
         private static async Task Main(string[] args)
         {
             Subsidiaries = new List<int>();
-            
             Instances = new List<ServerInstance>();
+            InstanceHeartBeats = new Dictionary<string, int>();
+            InstanceHealth = new Dictionary<string, ServerHealth>();
+            
             try
             {
-                // Throws FileNotFoundException / DirectoryNotFoundException when res folder or instance dll is specified incorrectly
                 await ConfigureAsync();
             }
             catch (Exception e) when (e is FileNotFoundException || e is DirectoryNotFoundException)
@@ -64,7 +71,6 @@ namespace Uchu.Master
             }
             
             var databaseVerified = await CheckForDatabaseUpdatesAsync();
-
             if (!databaseVerified)
             {
                 Logger.Error($"Failed to connect to database provider \"{Config.Database.Provider}\".");
@@ -81,6 +87,53 @@ namespace Uchu.Master
             AppDomain.CurrentDomain.ProcessExit += ShutdownProcesses;
             
             await SetupApiAsync();
+            
+            // Setup health checks and automatic server closing
+            InstanceHeartBeatCheck = new Timer(60000);
+            InstanceHeartBeatCheck.Elapsed += async (sender, eventArgs) =>
+            {
+                foreach (var instance in Instances.Where(i => i.ServerType == ServerType.World).ToList())
+                {
+                    var id = instance.Id.ToString();
+                    if (InstanceHealth.ContainsKey(id) && InstanceHeartBeats.ContainsKey(id))
+                    {
+                        InstanceHealth[id] = (InstanceHeartBeats[id] != 0 
+                                ? (float) InstanceHeartBeats[id] / WorldServerHeartBeatsPerMinute : 0) switch
+                        {
+                            var health when health >= 1 => ServerHealth.Healthy,
+                            var health when health >= 0.75 => ServerHealth.Lagging,
+                            var health when health >= 0.5 => ServerHealth.SeverelyLagging,
+                            var health when health >= 0.25 => ServerHealth.Unhealthy,
+                            
+                            // If hardly any heartbeats were received, gradually downgrade the health until closing
+                            _ => (ServerHealth) (int) InstanceHealth[id] - 1
+                        };
+                    }
+                    else
+                    {
+                        InstanceHealth.Add(id, ServerHealth.Dead);
+                    }
+
+                    Logger.Information($"{id} is {InstanceHealth[id]}");
+                    InstanceHeartBeats[id] = 0;
+                }
+                
+                // Kill all unhealthy instances
+                foreach (var unhealthyInstance in Instances.Where(i => i.ServerType == ServerType.World
+                                                                       && InstanceHealth.TryGetValue(i.Id.ToString(),
+                                                                           out var health)
+                                                                       && health == ServerHealth.Dead).ToList())
+                {
+                    Logger.Information($"Closing {unhealthyInstance.Id.ToString()} " +
+                                       $"({InstanceHealth[unhealthyInstance.Id.ToString()]}) due to health status.");
+                    
+                    await Api.RunCommandAsync<BaseResponse>(ApiPort, 
+                        $"instance/decommission?instance={unhealthyInstance.Id.ToString()}");
+                }
+            };
+            
+            InstanceHeartBeatCheck.Enabled = true;
+            InstanceHeartBeatCheck.AutoReset = true;
             
             try
             {
@@ -292,6 +345,7 @@ namespace Uchu.Master
             }
 
             ApiPortIndex = Config.ApiConfig.Port;
+            WorldServerHeartBeatsPerMinute = Config.Networking.WorldServerHeartbeatsPerMinute;
 
             var source = Directory.GetCurrentDirectory();
             
@@ -322,6 +376,12 @@ namespace Uchu.Master
             instance.Start(DllLocation, Config.DllSource.DotNetPath);
             
             Instances.Add(instance);
+
+            if (type == ServerType.World)
+            {
+                InstanceHeartBeats.Add(id.ToString(), 0);
+                InstanceHealth.Add(id.ToString(), ServerHealth.Healthy);
+            }
 
             return id;
         }

--- a/Uchu.Master/ServerHealth.cs
+++ b/Uchu.Master/ServerHealth.cs
@@ -1,0 +1,11 @@
+namespace Uchu.Master
+{
+    public enum ServerHealth
+    {
+        Dead, // Missed all heart beats
+        Unhealthy, // Missed 75% of the required heart beats
+        SeverelyLagging, // Missed 50% of the required heart beats
+        Lagging, // Missed a heart beat
+        Healthy, // Hits all heart beats
+    }
+}

--- a/Uchu.World/Objects/Components/ReplicaComponents/PetComponent.cs
+++ b/Uchu.World/Objects/Components/ReplicaComponents/PetComponent.cs
@@ -78,7 +78,7 @@ namespace Uchu.World
             if (PetWild)
             {
                 XmlDocument doc = new XmlDocument();
-                doc.Load(Path.Combine(Zone.UchuServer.Config.ResourcesConfiguration.GameResourceFolder,
+                doc.Load(Path.Combine(Zone.Server.Config.ResourcesConfiguration.GameResourceFolder,
                     ClientCache.GetTable<TamingBuildPuzzles>().FirstOrDefault(i => i.NPCLot == GameObject.Lot)
                     .ValidPiecesLXF));
 

--- a/Uchu.World/Objects/Object.cs
+++ b/Uchu.World/Objects/Object.cs
@@ -9,7 +9,7 @@ namespace Uchu.World
 
         public Zone Zone { get; protected set; }
 
-        public UchuServer UchuServer => Zone.UchuServer;
+        public UchuServer UchuServer => Zone.Server;
 
         public Event OnStart { get; }
 

--- a/Uchu.World/Objects/Zone.cs
+++ b/Uchu.World/Objects/Zone.cs
@@ -13,6 +13,7 @@ using InfectedRose.Utilities;
 using RakDotNet;
 using RakDotNet.IO;
 using Sentry;
+using Uchu.Api.Models;
 using Uchu.Core;
 using Uchu.Core.Client;
 using Uchu.Physics;
@@ -38,9 +39,7 @@ namespace Uchu.World
         public uint CloneId { get; }
         public ushort InstanceId { get; }
         public ZoneInfo ZoneInfo { get; }
-        
-        public new UchuServer UchuServer { get; }
-        
+        public WorldUchuServer Server { get; }
         public uint Checksum { get; private set; }
         public bool Loaded { get; private set; }
         public NavMeshManager NavMeshManager { get; private set; }
@@ -68,6 +67,7 @@ namespace Uchu.World
         private long _physicsTime;
         private long _objectUpdateTime;
         private long _scheduleUpdateTime;
+        private long _timeSinceLastHeartBeat;
         
         public bool CalculatingTick { get; set; }
         public float DeltaTime { get; private set; }
@@ -89,11 +89,11 @@ namespace Uchu.World
         public Event OnTick { get; }
         public Event<Player, string> OnChatMessage { get; }
         
-        public Zone(ZoneInfo zoneInfo, UchuServer uchuServer, ushort instanceId = default, uint cloneId = default)
+        public Zone(ZoneInfo zoneInfo, WorldUchuServer server, ushort instanceId = default, uint cloneId = default)
         {
             Zone = this;
             ZoneInfo = zoneInfo;
-            UchuServer = uchuServer;
+            Server = server;
             InstanceId = instanceId;
             CloneId = cloneId;
             
@@ -223,7 +223,7 @@ namespace Uchu.World
         /// </summary>
         private async Task LoadNavMeshes()
         {
-            NavMeshManager = new NavMeshManager(this, UchuServer.Config.GamePlay.PathFinding);
+            NavMeshManager = new NavMeshManager(this, Server.Config.GamePlay.PathFinding);
             if (NavMeshManager.Enabled)
             {
                 Logger.Information("Generating navigation way points.");
@@ -641,6 +641,7 @@ namespace Uchu.World
             Listen(OnTick, ExecuteSchedule);
             Listen(OnTick, UpdateObjects);
             Listen(OnTick, PhysicsStep);
+            Listen(OnTick, SendHeartbeat);
 
             _running = true;
 
@@ -728,8 +729,21 @@ namespace Uchu.World
             
             watch.Stop();
             _objectUpdateTime += watch.ElapsedMilliseconds;
-        }    
+        }
 
+        /// <summary>
+        /// Sends a heart beat to the master server indicating that this server is still healthy
+        /// </summary>
+        private async Task SendHeartbeat()
+        {
+            _timeSinceLastHeartBeat += (long)DeltaTime;
+            if (_timeSinceLastHeartBeat >= Server.HeartBeatInterval)
+            {
+                await Server.SendHeartBeat();
+                _timeSinceLastHeartBeat = 0;
+            }
+        }
+        
         /// <summary>
         /// Decrements the delay of all scheduled tasks and executes them if the timeout has been reached
         /// </summary>

--- a/Uchu.World/Objects/Zone.cs
+++ b/Uchu.World/Objects/Zone.cs
@@ -623,7 +623,7 @@ namespace Uchu.World
             _passedTickTime += passedMs;
 
             DeltaTime = Math.Max(TimePerTickLimit, passedMs);
-            
+
             CalculatingTick = false;
         }
 

--- a/Uchu.World/Scripting/Managed/PythonScriptPack.cs
+++ b/Uchu.World/Scripting/Managed/PythonScriptPack.cs
@@ -25,11 +25,11 @@ namespace Uchu.World.Scripting.Managed
         {
             Logger.Information($"Loading python script pack: {Name}");
 
-            var location = Path.Combine(Zone.UchuServer.MasterPath, Location);
+            var location = Path.Combine(Zone.Server.MasterPath, Location);
             
             if (File.Exists(location))
             {
-                var source = await File.ReadAllTextAsync(Path.Combine(Zone.UchuServer.MasterPath, location));
+                var source = await File.ReadAllTextAsync(Path.Combine(Zone.Server.MasterPath, location));
 
                 var script = new PythonScript(source, Zone);
 

--- a/Uchu.World/Scripting/Native/NativeScript.cs
+++ b/Uchu.World/Scripting/Native/NativeScript.cs
@@ -10,7 +10,7 @@ namespace Uchu.World.Scripting.Native
     {
         protected Zone Zone { get; private set; }
 
-        protected UchuServer UchuServer => Zone.UchuServer;
+        protected UchuServer UchuServer => Zone.Server;
 
         protected static void Start(Object obj) => Object.Start(obj);
         

--- a/Uchu.World/Scripting/ScriptManager.cs
+++ b/Uchu.World/Scripting/ScriptManager.cs
@@ -39,7 +39,7 @@ namespace Uchu.World.Scripting
             
             var scriptPacks = new List<ScriptPack>();
             
-            foreach (var scriptPackPath in Zone.UchuServer.Config.DllSource.ScriptDllSource)
+            foreach (var scriptPackPath in Zone.Server.Config.DllSource.ScriptDllSource)
             {
                 try
                 {
@@ -68,13 +68,13 @@ namespace Uchu.World.Scripting
             
             ManagedScriptEngine.Init();
 
-            foreach (var script in Zone.UchuServer.Config.ManagedScriptSources?.Scripts ?? new List<string>())
+            foreach (var script in Zone.Server.Config.ManagedScriptSources?.Scripts ?? new List<string>())
             {
                 Logger.Information($"Loading {script} managed script pack");
                 
                 string source = default;
 
-                var location = Path.Combine(Zone.UchuServer.MasterPath, script);
+                var location = Path.Combine(Zone.Server.MasterPath, script);
                 
                 if (File.Exists(location))
                 {
@@ -104,7 +104,7 @@ namespace Uchu.World.Scripting
 
             ScriptPacks = list;
 
-            location = Path.Combine(Zone.UchuServer.MasterPath, location);
+            location = Path.Combine(Zone.Server.MasterPath, location);
 
             if (File.Exists(location))
             {

--- a/Uchu.World/Systems/Match/MatchInstance.cs
+++ b/Uchu.World/Systems/Match/MatchInstance.cs
@@ -104,7 +104,7 @@ namespace Uchu.World.Systems.Match
                 InstanceInfo allocatedInstance;
                 try
                 {
-                    allocatedInstance = await ServerHelper.RequestNewWorldServerAsync(zone.UchuServer, (ZoneId) matchZoneId);
+                    allocatedInstance = await ServerHelper.RequestNewWorldServerAsync(zone.Server, (ZoneId) matchZoneId);
                     if (allocatedInstance == default)
                     {
                         Logger.Debug($"Could not find server for: {matchZoneId}");

--- a/Uchu.World/WorldUchuServer.cs
+++ b/Uchu.World/WorldUchuServer.cs
@@ -35,15 +35,6 @@ namespace Uchu.World
         public Whitelist Whitelist { get; private set; }
 
         /// <summary>
-        /// The interval at which heart beats should be sent
-        /// </summary>
-        /// <remarks>
-        /// Returns essentially one heart beat more than absolutely necessary for a healthy status to ensure that small
-        /// hick ups and lag do not interfere with overall server health 
-        /// </remarks>
-        public float HeartBeatInterval => 60 / (HeartBeatsPerMinute + 1) * 1000;
-
-        /// <summary>
         /// Sends a heart beat to the master server, indicating the health of the server
         /// </summary>
         public async Task SendHeartBeat()
@@ -65,15 +56,6 @@ namespace Uchu.World
         {
             Logger.Information($"Created WorldServer on PID {Process.GetCurrentProcess().Id.ToString()}");
             await base.ConfigureAsync(configFile);
-            
-            // Timer to ensure the server doesn't get shut down during loading
-            var loadingHeartBeatTimer = new Timer(HeartBeatInterval);
-            loadingHeartBeatTimer.Elapsed += async (sender, args) =>
-            {
-                await SendHeartBeat();
-            };
-            loadingHeartBeatTimer.Enabled = true;
-            loadingHeartBeatTimer.AutoReset = true;
 
             ZoneParser = new ZoneParser(Resources);
             Whitelist = new Whitelist(Resources);
@@ -114,10 +96,6 @@ namespace Uchu.World
                 {
                     await ZoneParser.LoadZoneDataAsync(zone);
                     await LoadZone(zone);
-                    
-                    // If we're done loading, the zones send heart beats
-                    if (Zones.Count >= info.Info.Zones.Count)
-                        loadingHeartBeatTimer.Stop();
                 }
             });
         }


### PR DESCRIPTION
Improves logging for smaller windows by aligning the invoker text at the right to the window edge.
### Before
![logging_old](https://user-images.githubusercontent.com/11255568/110202954-e4ca5d80-7e6b-11eb-843f-0fa1b3eaecba.png)
### After
![logging_new](https://user-images.githubusercontent.com/11255568/110202959-e7c54e00-7e6b-11eb-894d-131682b73b0a.png)

I've also made the logs from MasterServer.ConfigureAsync a bit clearer and changed the timestamps from month-day-year with 12h time to year-month-day with 24h time.