### PR TITLE
Make Physics Objects Thread-Safe

### DIFF
--- a/Uchu.Physics/Callbacks/NarrowPhaseCallbacks.cs
+++ b/Uchu.Physics/Callbacks/NarrowPhaseCallbacks.cs
@@ -4,6 +4,7 @@ using BepuPhysics;
 using BepuPhysics.Collidables;
 using BepuPhysics.CollisionDetection;
 using BepuPhysics.Constraints;
+using Uchu.Core;
 
 namespace Uchu.Physics.Callbacks
 {
@@ -89,7 +90,7 @@ namespace Uchu.Physics.Callbacks
             }
             catch (Exception e)
             {
-                Console.WriteLine(e);
+                Logger.Error(e);
             }
 
             return false;

--- a/Uchu.Physics/Objects/Dynamic/BoxBody.cs
+++ b/Uchu.Physics/Objects/Dynamic/BoxBody.cs
@@ -27,12 +27,12 @@ namespace Uchu.Physics
         {
             var shape = new Box(size.X, size.Y, size.Z);
             shape.ComputeInertia(1, out var inertia);
-            var index = simulation.Simulation.Shapes.Add(shape);
+            var index = simulation.RegisterShape(shape);
             var collidable = new CollidableDescription(index, 0.1f);
             var activity = new BodyActivityDescription(0);
             var pose = new RigidPose(position, rotation);
             var descriptor = BodyDescription.CreateDynamic(pose, inertia, collidable, activity);
-            var handle = simulation.Simulation.Bodies.Add(descriptor);
+            var handle = simulation.CreateBodyHandle(descriptor);
             var obj = new BoxBody(simulation, handle);
             simulation.Register(obj);
             

--- a/Uchu.Physics/Objects/Dynamic/BoxBody.cs
+++ b/Uchu.Physics/Objects/Dynamic/BoxBody.cs
@@ -6,32 +6,36 @@ namespace Uchu.Physics
 {
     public class BoxBody : PhysicsBody
     {
+        /// <summary>
+        /// Creates a box body.
+        /// </summary>
+        /// <param name="simulation">The simulation to use.</param>
+        /// <param name="handle">Body handle to use.</param>
         public BoxBody(PhysicsSimulation simulation, BodyHandle handle) : base(simulation, handle)
         {
         }
 
+        /// <summary>
+        /// Creates a box body.
+        /// </summary>
+        /// <param name="simulation">The simulation to use.</param>
+        /// <param name="position">The position of the body.</param>
+        /// <param name="rotation">The rotation of the body.</param>
+        /// <param name="size">The size of the body.</param>
+        /// <returns>The box body that was created.</returns>
         public static BoxBody Create(PhysicsSimulation simulation, Vector3 position, Quaternion rotation, Vector3 size)
         {
             var shape = new Box(size.X, size.Y, size.Z);
-
             shape.ComputeInertia(1, out var inertia);
-
             var index = simulation.Simulation.Shapes.Add(shape);
-
             var collidable = new CollidableDescription(index, 0.1f);
-            
             var activity = new BodyActivityDescription(0);
-
             var pose = new RigidPose(position, rotation);
-            
             var descriptor = BodyDescription.CreateDynamic(pose, inertia, collidable, activity);
-
             var handle = simulation.Simulation.Bodies.Add(descriptor);
-
             var obj = new BoxBody(simulation, handle);
-
             simulation.Register(obj);
-
+            
             return obj;
         }
     }

--- a/Uchu.Physics/Objects/Dynamic/CapsuleBody.cs
+++ b/Uchu.Physics/Objects/Dynamic/CapsuleBody.cs
@@ -6,30 +6,34 @@ namespace Uchu.Physics
 {
     public class CapsuleBody : PhysicsBody
     {
+        /// <summary>
+        /// Creates a capsule body.
+        /// </summary>
+        /// <param name="simulation">The simulation to use.</param>
+        /// <param name="handle">Body handle to use.</param>
         public CapsuleBody(PhysicsSimulation simulation, BodyHandle handle) : base(simulation, handle)
         {
         }
 
+        /// <summary>
+        /// Creates a capsule body.
+        /// </summary>
+        /// <param name="simulation">The simulation to use.</param>
+        /// <param name="position">The position of the body.</param>
+        /// <param name="rotation">The rotation of the body.</param>
+        /// <param name="size">The size of the body.</param>
+        /// <returns>The capsule body that was created.</returns>
         public static CapsuleBody Create(PhysicsSimulation simulation, Vector3 position, Quaternion rotation, Vector2 size)
         {
             var shape = new Capsule(size.X, size.Y);
-
             shape.ComputeInertia(1, out var inertia);
-
             var index = simulation.Simulation.Shapes.Add(shape);
-
             var collidable = new CollidableDescription(index, 0.1f);
-            
             var activity = new BodyActivityDescription(0.01f);
-
             var pose = new RigidPose(position, rotation);
-            
             var descriptor = BodyDescription.CreateDynamic(pose, inertia, collidable, activity);
-
             var handle = simulation.Simulation.Bodies.Add(descriptor);
-
             var obj = new CapsuleBody(simulation, handle);
-
             simulation.Register(obj);
 
             return obj;

--- a/Uchu.Physics/Objects/Dynamic/CapsuleBody.cs
+++ b/Uchu.Physics/Objects/Dynamic/CapsuleBody.cs
@@ -27,12 +27,12 @@ namespace Uchu.Physics
         {
             var shape = new Capsule(size.X, size.Y);
             shape.ComputeInertia(1, out var inertia);
-            var index = simulation.Simulation.Shapes.Add(shape);
+            var index = simulation.RegisterShape(shape);
             var collidable = new CollidableDescription(index, 0.1f);
             var activity = new BodyActivityDescription(0.01f);
             var pose = new RigidPose(position, rotation);
             var descriptor = BodyDescription.CreateDynamic(pose, inertia, collidable, activity);
-            var handle = simulation.Simulation.Bodies.Add(descriptor);
+            var handle = simulation.CreateBodyHandle(descriptor);
             var obj = new CapsuleBody(simulation, handle);
             simulation.Register(obj);
 

--- a/Uchu.Physics/Objects/Dynamic/CylinderBody.cs
+++ b/Uchu.Physics/Objects/Dynamic/CylinderBody.cs
@@ -27,12 +27,12 @@ namespace Uchu.Physics
         {
             var shape = new Cylinder(size.X, size.Y);
             shape.ComputeInertia(1, out var inertia);
-            var index = simulation.Simulation.Shapes.Add(shape);
+            var index = simulation.RegisterShape(shape);
             var collidable = new CollidableDescription(index, 0.1f);
             var activity = new BodyActivityDescription(0);
             var pose = new RigidPose(position, rotation);
             var descriptor = BodyDescription.CreateDynamic(pose, inertia, collidable, activity);
-            var handle = simulation.Simulation.Bodies.Add(descriptor);
+            var handle = simulation.CreateBodyHandle(descriptor);
             var obj = new CylinderBody(simulation, handle);
             simulation.Register(obj);
 

--- a/Uchu.Physics/Objects/Dynamic/CylinderBody.cs
+++ b/Uchu.Physics/Objects/Dynamic/CylinderBody.cs
@@ -6,30 +6,34 @@ namespace Uchu.Physics
 {
     public class CylinderBody : PhysicsBody
     {
+        /// <summary>
+        /// Creates a cylinder body.
+        /// </summary>
+        /// <param name="simulation">The simulation to use.</param>
+        /// <param name="handle">Body handle to use.</param>
         public CylinderBody(PhysicsSimulation simulation, BodyHandle handle) : base(simulation, handle)
         {
         }
 
+        /// <summary>
+        /// Creates a cylinder body.
+        /// </summary>
+        /// <param name="simulation">The simulation to use.</param>
+        /// <param name="position">The position of the body.</param>
+        /// <param name="rotation">The rotation of the body.</param>
+        /// <param name="size">The size of the body.</param>
+        /// <returns>The cylinder body that was created.</returns>
         public static CylinderBody Create(PhysicsSimulation simulation, Vector3 position, Quaternion rotation, Vector2 size)
         {
             var shape = new Cylinder(size.X, size.Y);
-
             shape.ComputeInertia(1, out var inertia);
-
             var index = simulation.Simulation.Shapes.Add(shape);
-
             var collidable = new CollidableDescription(index, 0.1f);
-            
             var activity = new BodyActivityDescription(0);
-
             var pose = new RigidPose(position, rotation);
-            
             var descriptor = BodyDescription.CreateDynamic(pose, inertia, collidable, activity);
-
             var handle = simulation.Simulation.Bodies.Add(descriptor);
-
             var obj = new CylinderBody(simulation, handle);
-
             simulation.Register(obj);
 
             return obj;

--- a/Uchu.Physics/Objects/Dynamic/PhysicsBody.cs
+++ b/Uchu.Physics/Objects/Dynamic/PhysicsBody.cs
@@ -5,83 +5,87 @@ namespace Uchu.Physics
 {
     public abstract class PhysicsBody : PhysicsObject
     {
+        /// <summary>
+        /// Handle of the physics body.
+        /// </summary>
         internal BodyHandle Handle { get; }
         
+        /// <summary>
+        /// Reference of the physics body.
+        /// </summary>
         internal BodyReference Reference { get; }
 
+        /// <summary>
+        /// Creates a physics body.
+        /// </summary>
+        /// <param name="simulation">The simulation to use.</param>
+        /// <param name="handle">Body handle to use.</param>
         protected PhysicsBody(PhysicsSimulation simulation, BodyHandle handle) : base(simulation)
         {
             Handle = handle;
-
             Reference = simulation.Simulation.Bodies.GetBodyReference(handle);
         }
 
+        /// <summary>
+        /// Id of the physics object.
+        /// </summary>
         public override int Id => Handle.Value;
 
+        /// <summary>
+        /// Position of the physics object.
+        /// </summary>
         public override Vector3 Position
         {
-            get
-            {
-                if (!Reference.Exists) return default;
-                
-                return Reference.Pose.Position;
-            }
+            get => !Reference.Exists ? default : Reference.Pose.Position;
             set
             {
                 if (!Reference.Exists) return;
-                
                 Reference.Pose.Position = value;
             }
         }
 
+        /// <summary>
+        /// Rotation of the physics object.
+        /// </summary>
         public Quaternion Rotation
         {
-            get
-            {
-                if (!Reference.Exists) return default;
-
-                return Reference.Pose.Orientation;
-            }
+            get => !Reference.Exists ? default : Reference.Pose.Orientation;
             set
             {
                 if (!Reference.Exists) return;
-                
                 Reference.Pose.Orientation = value;
             }
         }
-
+        
+        /// <summary>
+        /// Angular velocity of the physics object.
+        /// </summary>
         public Vector3 AngularVelocity
         {
-            get
-            {
-                if (!Reference.Exists) return default;
-
-                return Reference.Velocity.Angular;
-            }
+            get => !Reference.Exists ? default : Reference.Velocity.Angular;
             set
             {
                 if (!Reference.Exists) return;
-                
                 Reference.Velocity.Angular = value;
             }
         }
 
+        /// <summary>
+        /// Velocity of the physics object.
+        /// </summary>
         public Vector3 LinearVelocity
         {
-            get
-            {
-                if (!Reference.Exists) return default;
-
-                return Reference.Velocity.Linear;
-            }
+            get => !Reference.Exists ? default : Reference.Velocity.Linear;
             set
             {
                 if (!Reference.Exists) return;
-                
                 Reference.Velocity.Linear = value;
             }
         }
 
+        /// <summary>
+        /// Disposes the physics object.
+        /// </summary>
         public override void Dispose()
         {
             Simulation.Release(this);

--- a/Uchu.Physics/Objects/Dynamic/PhysicsBody.cs
+++ b/Uchu.Physics/Objects/Dynamic/PhysicsBody.cs
@@ -23,7 +23,7 @@ namespace Uchu.Physics
         protected PhysicsBody(PhysicsSimulation simulation, BodyHandle handle) : base(simulation)
         {
             Handle = handle;
-            Reference = simulation.Simulation.Bodies.GetBodyReference(handle);
+            Reference = simulation.GetBodyReference(handle);
         }
 
         /// <summary>
@@ -89,10 +89,8 @@ namespace Uchu.Physics
         public override void Dispose()
         {
             Simulation.Release(this);
-            
             if (!Reference.Exists) return;
-            
-            Simulation.Simulation.Bodies.Remove(Handle);
+            Simulation.RemoveBodyHandle(Handle);
         }
     }
 }

--- a/Uchu.Physics/Objects/PhysicsObject.cs
+++ b/Uchu.Physics/Objects/PhysicsObject.cs
@@ -5,21 +5,43 @@ namespace Uchu.Physics
 {
     public abstract class PhysicsObject : IDisposable
     {
+        /// <summary>
+        /// Event for a collision occuring with another object.
+        /// </summary>
         public Action<PhysicsObject> OnCollision { get; set; }
         
+        /// <summary>
+        /// Id of the physics object.
+        /// </summary>
         public abstract int Id { get; }
         
+        /// <summary>
+        /// Simulation attached to the physics object.
+        /// </summary>
         public PhysicsSimulation Simulation { get; }
         
+        /// <summary>
+        /// Game object attached to the physics component.
+        /// </summary>
         public object Associate { get; set; }
 
+        /// <summary>
+        /// Creates the physics object,
+        /// </summary>
+        /// <param name="simulation">Simulation to use.</param>
         protected PhysicsObject(PhysicsSimulation simulation)
         {
             Simulation = simulation;
         }
         
+        /// <summary>
+        /// Position of the physics object.
+        /// </summary>
         public virtual Vector3 Position { get; set; }
 
+        /// <summary>
+        /// Disposes the physics object.
+        /// </summary>
         public abstract void Dispose();
     }
 }

--- a/Uchu.Physics/Objects/Static/PhysicsStatic.cs
+++ b/Uchu.Physics/Objects/Static/PhysicsStatic.cs
@@ -23,7 +23,7 @@ namespace Uchu.Physics
         public PhysicsStatic(PhysicsSimulation simulation, StaticHandle handle) : base(simulation)
         {
             Handle = handle;
-            Reference = simulation.Simulation.Statics.GetStaticReference(handle);
+            Reference = simulation.GetStaticReference(handle);
         }
 
         /// <summary>
@@ -43,7 +43,7 @@ namespace Uchu.Physics
         {
             Simulation.Release(this);
             if (!Reference.Exists) return;
-            Simulation.Simulation.Statics.Remove(Handle);
+            Simulation.RemoveStaticHandle(Handle);
         }
     }
 }

--- a/Uchu.Physics/Objects/Static/PhysicsStatic.cs
+++ b/Uchu.Physics/Objects/Static/PhysicsStatic.cs
@@ -5,35 +5,44 @@ namespace Uchu.Physics
 {
     public abstract class PhysicsStatic : PhysicsObject
     {
+        /// <summary>
+        /// Static handle for physics.
+        /// </summary>
         internal StaticHandle Handle { get; }
         
+        /// <summary>
+        /// Reference for the static physics object.
+        /// </summary>
         internal StaticReference Reference { get; }
 
+        /// <summary>
+        /// Creates a static physics object.
+        /// </summary>
+        /// <param name="simulation">The simulation to use.</param>
+        /// <param name="handle">Static handle to use.</param>
         public PhysicsStatic(PhysicsSimulation simulation, StaticHandle handle) : base(simulation)
         {
             Handle = handle;
-
             Reference = simulation.Simulation.Statics.GetStaticReference(handle);
         }
 
+        /// <summary>
+        /// Id of the physics object.
+        /// </summary>
         public override int Id => Handle.Value;
 
-        public override Vector3 Position
-        {
-            get
-            {
-                if (!Reference.Exists) return default;
-                
-                return Reference.Pose.Position;
-            }
-        }
+        /// <summary>
+        /// Position of the physics object.
+        /// </summary>
+        public override Vector3 Position => !Reference.Exists ? default : Reference.Pose.Position;
 
+        /// <summary>
+        /// Disposes the physics object.
+        /// </summary>
         public override void Dispose()
         {
             Simulation.Release(this);
-            
             if (!Reference.Exists) return;
-            
             Simulation.Simulation.Statics.Remove(Handle);
         }
     }

--- a/Uchu.Physics/Objects/Static/TriggerBox.cs
+++ b/Uchu.Physics/Objects/Static/TriggerBox.cs
@@ -6,24 +6,31 @@ namespace Uchu.Physics
 {
     public class TriggerBox : PhysicsStatic
     {
+        /// <summary>
+        /// Creates a trigger box.
+        /// </summary>
+        /// <param name="simulation">The simulation to use.</param>
+        /// <param name="handle">Static handle to use.</param>
         public TriggerBox(PhysicsSimulation simulation, StaticHandle handle) : base(simulation, handle)
         {
         }
 
+        /// <summary>
+        /// Creates a trigger box.
+        /// </summary>
+        /// <param name="simulation">The simulation to use.</param>
+        /// <param name="position">The static position of the trigger box.</param>
+        /// <param name="rotation">The static rotation of the trigger box.</param>
+        /// <param name="size">The static size of the trigger box.</param>
+        /// <returns>The trigger box that was created.</returns>
         public static TriggerBox Create(PhysicsSimulation simulation, Vector3 position, Quaternion rotation, Vector3 size)
         {
             var shape = new Box(size.X, size.Y, size.Z);
-
             var index = simulation.Simulation.Shapes.Add(shape);
-
             var collidable = new CollidableDescription(index, 0.01f);
-
             var descriptor = new StaticDescription(position, rotation, collidable);
-
             var handle = simulation.Simulation.Statics.Add(descriptor);
-
             var obj = new TriggerBox(simulation, handle);
-
             simulation.Register(obj);
 
             return obj;

--- a/Uchu.Physics/Objects/Static/TriggerBox.cs
+++ b/Uchu.Physics/Objects/Static/TriggerBox.cs
@@ -26,10 +26,10 @@ namespace Uchu.Physics
         public static TriggerBox Create(PhysicsSimulation simulation, Vector3 position, Quaternion rotation, Vector3 size)
         {
             var shape = new Box(size.X, size.Y, size.Z);
-            var index = simulation.Simulation.Shapes.Add(shape);
+            var index = simulation.RegisterShape(shape);
             var collidable = new CollidableDescription(index, 0.01f);
             var descriptor = new StaticDescription(position, rotation, collidable);
-            var handle = simulation.Simulation.Statics.Add(descriptor);
+            var handle = simulation.CreateStaticHandle(descriptor);
             var obj = new TriggerBox(simulation, handle);
             simulation.Register(obj);
 

--- a/Uchu.Physics/PhysicsSimulation.cs
+++ b/Uchu.Physics/PhysicsSimulation.cs
@@ -5,39 +5,60 @@ using System.Numerics;
 using BepuPhysics;
 using BepuPhysics.Collidables;
 using BepuUtilities.Memory;
+using Uchu.Core;
 using Uchu.Physics.Callbacks;
 
 namespace Uchu.Physics
 {
     public class PhysicsSimulation : IDisposable
     {
+        /// <summary>
+        /// BepuPhysics simulation.
+        /// </summary>
         internal Simulation Simulation { get; }
         
-        internal BufferPool Buffer { get; }
+        /// <summary>
+        /// Buffer for BepuPhysics.
+        /// </summary>
+        private BufferPool Buffer { get; }
         
-        internal NarrowPhaseCallbacks NarrowPhaseCallbacks { get; }
+        /// <summary>
+        /// Callback object for handling collisions.
+        /// </summary>
+        private NarrowPhaseCallbacks NarrowPhaseCallbacks { get; }
         
-        internal PoseIntegratorCallbacks PoseIntegratorCallbacks { get; }
+        /// <summary>
+        /// Callback object for pose integration.
+        /// </summary>
+        private PoseIntegratorCallbacks PoseIntegratorCallbacks { get; }
         
-        public List<PhysicsObject> Objects { get; }
+        /// <summary>
+        /// Objects in the simulation.
+        /// </summary>
+        private List<PhysicsObject> Objects { get; }
 
+        /// <summary>
+        /// Getter for the static physics objects.
+        /// </summary>
         public IEnumerable<PhysicsStatic> Statics => Objects.OfType<PhysicsStatic>();
 
+        /// <summary>
+        /// Getter for the physics bodies.
+        /// </summary>
         public IEnumerable<PhysicsBody> Bodies => Objects.OfType<PhysicsBody>();
 
+        /// <summary>
+        /// Creates the physics simulation.
+        /// </summary>
         public PhysicsSimulation()
         {
             Objects = new List<PhysicsObject>();
-            
             Buffer = new BufferPool();
-            
             NarrowPhaseCallbacks = new NarrowPhaseCallbacks
             {
                 OnCollision = HandleCollision
             };
-
             PoseIntegratorCallbacks = new PoseIntegratorCallbacks(Vector3.Zero);
-
             Simulation = Simulation.Create(Buffer, NarrowPhaseCallbacks, PoseIntegratorCallbacks);
         }
 
@@ -65,61 +86,87 @@ namespace Uchu.Physics
             Simulation.Timestep(deltaTime / 1000);
         }
 
+        /// <summary>
+        /// Registers a physics object.
+        /// </summary>
+        /// <param name="obj">Physics object to register.</param>
         internal void Register(PhysicsObject obj)
         {
             Objects.Add(obj);
         }
 
+        /// <summary>
+        /// Removes a physics object.
+        /// </summary>
+        /// <param name="obj">Physics object to remove.</param>
         internal void Release(PhysicsObject obj)
         {
             Objects.Remove(obj);
         }
         
+        /// <summary>
+        /// Handles a collision between 2 objects.
+        /// </summary>
+        /// <param name="referenceA">Reference to the first object.</param>
+        /// <param name="referenceB">Reference to the second object.</param>
+        /// <returns>Always false.</returns> 
         private bool HandleCollision(CollidableReference referenceA, CollidableReference referenceB)
         {
+            // Get the references.
             var a = FindObject(referenceA.StaticHandle, referenceA.BodyHandle);
-            
             var b = FindObject(referenceB.StaticHandle, referenceB.BodyHandle);
 
+            // Invoke the collision events.
             try
             {
                 a.OnCollision?.Invoke(b);
-
                 b.OnCollision?.Invoke(a);
             }
             catch (Exception e)
             {
-                Console.WriteLine(e);
+                Logger.Error(e);
             }
 
+            // Return false.
             return false;
         }
 
+        /// <summary>
+        /// Returns the object for the handles.
+        /// </summary>
+        /// <param name="staticHandle">Static handle to search by.</param>
+        /// <param name="bodyHandle">Body handle to search by.</param>
+        /// <returns>The physics object for the handles.</returns>
+        /// <exception cref="Exception">Failed to find the physics object.</exception>
         private PhysicsObject FindObject(StaticHandle staticHandle, BodyHandle bodyHandle)
         {
+            // Return if a body handle matches.
             foreach (var physicsObject in Bodies)
             {
                 if (!physicsObject.Reference.Exists) continue;
-                
                 if (physicsObject.Id == bodyHandle.Value)
                 {
                     return physicsObject;
                 }
             }
             
+            // Return if a static handle matches.
             foreach (var physicsObject in Statics)
             {
                 if (!physicsObject.Reference.Exists) continue;
-
                 if (physicsObject.Id == staticHandle.Value)
                 {
                     return physicsObject;
                 }
             }
 
+            // Throw an exception if nothing was found.
             throw new Exception($"Failed to find physics object: Got {staticHandle}/{bodyHandle}");
         }
-
+        
+        /// <summary>
+        /// Disposes the physics simulation.
+        /// </summary>
         public void Dispose()
         {
             Simulation?.Dispose();

--- a/Uchu.Physics/PhysicsSimulation.cs
+++ b/Uchu.Physics/PhysicsSimulation.cs
@@ -15,7 +15,7 @@ namespace Uchu.Physics
         /// <summary>
         /// BepuPhysics simulation.
         /// </summary>
-        internal Simulation Simulation { get; }
+        private Simulation Simulation { get; }
         
         /// <summary>
         /// Buffer for BepuPhysics.
@@ -162,6 +162,74 @@ namespace Uchu.Physics
 
             // Throw an exception if nothing was found.
             throw new Exception($"Failed to find physics object: Got {staticHandle}/{bodyHandle}");
+        }
+
+        /// <summary>
+        /// Registers a shape.
+        /// </summary>
+        /// <param name="shape">Shape to register.</param>
+        /// <returns>Index of the shape.</returns>
+        public TypedIndex RegisterShape<TShape>(TShape shape) where TShape : unmanaged, IShape
+        {
+            return Simulation.Shapes.Add(shape);
+        }
+
+        /// <summary>
+        /// Returns the static reference for a static handle.
+        /// </summary>
+        /// <param name="handle">Handle to use.</param>
+        /// <returns>Static reference for the given static handle.</returns>
+        public StaticReference GetStaticReference(StaticHandle handle)
+        {
+            return Simulation.Statics.GetStaticReference(handle);
+        }
+        
+        /// <summary>
+        /// Creates a static handle.
+        /// </summary>
+        /// <param name="description">Description of handle.</param>
+        /// <returns>The created static handle.</returns>
+        public StaticHandle CreateStaticHandle(StaticDescription description)
+        {
+            return Simulation.Statics.Add(description);
+        }
+
+        /// <summary>
+        /// Removes a static handle.
+        /// </summary>
+        /// <param name="handle">Handle to remove.</param>
+        public void RemoveStaticHandle(StaticHandle handle)
+        {
+            Simulation.Statics.Remove(handle);
+        }
+
+        /// <summary>
+        /// Returns the body reference for a body handle.
+        /// </summary>
+        /// <param name="handle">Handle to use.</param>
+        /// <returns>Body reference for the given body handle.</returns>
+        public BodyReference GetBodyReference(BodyHandle handle)
+        {
+            return Simulation.Bodies.GetBodyReference(handle);
+        }
+
+        /// <summary>
+        /// Creates a body handle.
+        /// </summary>
+        /// <param name="description">Description of handle.</param>
+        /// <returns>The created body handle.</returns>
+        public BodyHandle CreateBodyHandle(BodyDescription description)
+        {
+            return Simulation.Bodies.Add(description);
+        }
+        
+        /// <summary>
+        /// Removes a body handle.
+        /// </summary>
+        /// <param name="handle">Handle to remove.</param>
+        public void RemoveBodyHandle(BodyHandle handle)
+        {
+            Simulation.Bodies.Remove(handle);
         }
         
         /// <summary>

--- a/Uchu.Physics/Uchu.Physics.csproj
+++ b/Uchu.Physics/Uchu.Physics.csproj
@@ -8,4 +8,8 @@
       <PackageReference Include="BepuPhysics" Version="2.2.0" />
     </ItemGroup>
 
+    <ItemGroup>
+      <ProjectReference Include="..\Uchu.Core\Uchu.Core.csproj" />
+    </ItemGroup>
+
 </Project>


### PR DESCRIPTION
This pull request *attempts* to fix the log overflow from the physics errors as well as abrupt crashes from the physics due to the implementation not being thread-safe. The code changes include reformatting for the current code format used by the project and ensuring the physics simulation modifications are handled with a semaphore.