### PR TITLE
Wait for instance to be ready before transferring

### DIFF
--- a/Uchu.Core/Api/InstanceCommands.cs
+++ b/Uchu.Core/Api/InstanceCommands.cs
@@ -25,6 +25,13 @@ namespace Uchu.Core.Api
                 return response;
             }
 
+            if (!UchuServer.RakNetServer.TcpStarted)
+            {
+                response.FailedReason = "not ready";
+
+                return response;
+            }
+
             response.Success = true;
             
             return response;

--- a/Uchu.Core/Config/UchuConfiguration.cs
+++ b/Uchu.Core/Config/UchuConfiguration.cs
@@ -341,5 +341,10 @@ namespace Uchu.Core.Config
         /// Whether the server should display a "Press any key to exit" prompt before exiting due to a fatal error
         /// </summary>
         [XmlElement] public bool PressKeyToExit { get; set; } = true;
+
+        /// <summary>
+        /// How long the server should wait for newly created instances to get ready before throwing a timeout exception
+        /// </summary>
+        [XmlElement] public int InstanceCommissionTimeout { get; set; } = 30000;
     }
 }

--- a/Uchu.Master/Api/MasterCommands.cs
+++ b/Uchu.Master/Api/MasterCommands.cs
@@ -206,8 +206,8 @@ namespace Uchu.Master.Api
             response.Id = id;
             response.ApiPort = instance.ApiPort;
 
-            var timeout = 5000; // time after which to give up on instance commission
-            var delay = 50; // time in between server/verify API calls
+            var timeout = 30000; // time (ms) after which to give up on instance commission
+            var delay = 300; // time (ms) in between server/verify API calls
 
             while (true)
             {

--- a/Uchu.Master/Api/MasterCommands.cs
+++ b/Uchu.Master/Api/MasterCommands.cs
@@ -194,46 +194,30 @@ namespace Uchu.Master.Api
 
             response.ApiPort = instance.ApiPort;
 
-            var timeout = 1000;
+            var timeout = 5000; // time after which to give up on instance commission
+            var delay = 50; // time in between server/verify API calls
 
             while (true)
             {
-                try
+                var verify = await MasterServer.Api.RunCommandAsync<ReadyCallbackResponse>(
+                    instance.ApiPort, "server/verify"
+                ).ConfigureAwait(false);
+
+                if (!(verify is {Success: true}))
                 {
-                    var verify = await MasterServer.Api.RunCommandAsync<ReadyCallbackResponse>(
-                        instance.ApiPort, "server/verify"
-                    ).ConfigureAwait(false);
+                    timeout -= delay;
 
-                    try
-                    {
-                        if (verify == null) throw new Exception("ReadyCallbackResponse was null");
-
-                        if (!verify.Success)
-                        {
-                            Logger.Error(verify.FailedReason);
-
-                            throw new Exception(verify.FailedReason);
-                        }
-                    } catch (Exception e) {
-                        Logger.Log(e.Message, LogLevel.Error);
-                    }
-
-
-                    instance.Ready = true;
-                    
-                    break;
-                }
-                catch
-                {
                     if (timeout <= 0)
                     {
-                        throw new TimeoutException("commission timed out");
+                        throw new TimeoutException("Commission timed out");
                     }
-                    
-                    await Task.Delay(50);
 
-                    timeout--;
+                    await Task.Delay(delay);
+                    continue;
                 }
+
+                instance.Ready = true;
+                break;
             }
 
             return response;

--- a/Uchu.Master/Api/MasterCommands.cs
+++ b/Uchu.Master/Api/MasterCommands.cs
@@ -206,8 +206,8 @@ namespace Uchu.Master.Api
             response.Id = id;
             response.ApiPort = instance.ApiPort;
 
-            var timeout = 30000; // time (ms) after which to give up on instance commission
-            var delay = 300; // time (ms) in between server/verify API calls
+            var timeout = MasterServer.Config.ServerBehaviour.InstanceCommissionTimeout;
+            var delay = 500; // time (ms) in between server/verify API calls
 
             while (true)
             {


### PR DESCRIPTION
Fixes #218 

This PR
a) makes the TCP server status publicly readable in IRakServer so the master server can check if the instance actually has the game server running before sending players
b) fixes a while loop that had a break statement in the wrong place causing it to always only run once, regardless of whether the instance was ready