### PR TITLE
Prepare For Releases

### DIFF
--- a/Uchu.Char/Packets/Client/CharacterListRequest.cs
+++ b/Uchu.Char/Packets/Client/CharacterListRequest.cs
@@ -1,3 +1,4 @@
+using RakDotNet.IO;
 using Uchu.Core;
 
 namespace Uchu.Char
@@ -7,5 +8,10 @@ namespace Uchu.Char
         public override RemoteConnectionType RemoteConnectionType => RemoteConnectionType.Client;
 
         public override uint PacketId => 0x2;
+
+        public override void Deserialize(BitReader reader)
+        {
+
+        }
     }
 }

--- a/Uchu.Core/Cache/DatabaseCache.cs
+++ b/Uchu.Core/Cache/DatabaseCache.cs
@@ -95,7 +95,7 @@ namespace Uchu.Core
             await using var ctx = new UchuContext();
             
             string key;
-            var timeout = 1000;
+            var timeout = 5000;
             
             while (!_keys.TryGetValue(endpoint.ToString(), out key))
             {

--- a/Uchu.Core/Config/UchuConfiguration.cs
+++ b/Uchu.Core/Config/UchuConfiguration.cs
@@ -42,7 +42,7 @@ namespace Uchu.Core.Config
         [XmlElement]
         public LoggingConfiguration ConsoleLogging { get; set; } = new LoggingConfiguration
         {
-            Level = LogLevel.Debug.ToString()
+            Level = LogLevel.Information.ToString()
         };
 
         /// <summary>

--- a/Uchu.Core/Config/UchuConfiguration.cs
+++ b/Uchu.Core/Config/UchuConfiguration.cs
@@ -142,7 +142,7 @@ namespace Uchu.Core.Config
         /// if no service is installed and the connection will
         /// always timeout.
         /// </summary>
-        [XmlElement] public bool UseService { get; set; } = true;
+        [XmlElement] public bool UseService { get; set; } = false;
         
         /// <summary>
         /// Hostname to use when connecting to the cache service

--- a/Uchu.Core/UchuServer.cs
+++ b/Uchu.Core/UchuServer.cs
@@ -717,7 +717,7 @@ namespace Uchu.Core
             if (task && res != null)
                 await ((Task) res).ConfigureAwait(false);
             if (res == null)
-                Logger.Warning($"Handler {handler.GetType().FullName} returned null for {endPoint}.");
+                Logger.Debug($"Handler {handler.GetType().FullName} returned null for {endPoint}.");
         }
     }
 }

--- a/Uchu.Master/MasterServer.cs
+++ b/Uchu.Master/MasterServer.cs
@@ -339,8 +339,14 @@ namespace Uchu.Master
                 Logger.SetConfiguration(Config);
                 Logger.SetServerTypeInformation("Master");
 
-                // Add default value for script DLL source
-                Config.DllSource.ScriptDllSource.Add("../../../../Uchu.StandardScripts/bin/Debug/net5.0/Uchu.StandardScripts.dll");
+                // Add default value for instance DLL source and script DLL source..
+                if (File.Exists("Uchu.Instance.dll"))
+                {
+                    Config.DllSource.Instance = "Uchu.Instance.dll";
+                }
+                Config.DllSource.ScriptDllSource.Add(File.Exists("Uchu.StandardScripts.dll")
+                    ? "Uchu.StandardScripts.dll"
+                    : "../../../../Uchu.StandardScripts/bin/Debug/net5.0/Uchu.StandardScripts.dll");
 
                 // Write config file
                 Config.Save(configFilename);

--- a/Uchu.Master/MasterServer.cs
+++ b/Uchu.Master/MasterServer.cs
@@ -371,6 +371,7 @@ namespace Uchu.Master
                 try
                 {
                     Config.ResourcesConfiguration.GameResourceFolder = FindNlulClientResources();
+                    Config.Save(configFilename);
                     Logger.Information($"Using automatically detected client resource folder: {Config.ResourcesConfiguration.GameResourceFolder}");
                 }
                 catch

--- a/Uchu.Master/MasterServer.cs
+++ b/Uchu.Master/MasterServer.cs
@@ -339,13 +339,13 @@ namespace Uchu.Master
                 Logger.SetConfiguration(Config);
                 Logger.SetServerTypeInformation("Master");
 
-                // Add default value for instance DLL source and script DLL source..
-                if (File.Exists("Uchu.Instance.dll"))
+                // Add default value for instance DLL source and script DLL source.
+                if (File.Exists("lib/Uchu.Instance.dll"))
                 {
-                    Config.DllSource.Instance = "Uchu.Instance.dll";
+                    Config.DllSource.Instance = "lib/Uchu.Instance.dll";
                 }
-                Config.DllSource.ScriptDllSource.Add(File.Exists("Uchu.StandardScripts.dll")
-                    ? "Uchu.StandardScripts.dll"
+                Config.DllSource.ScriptDllSource.Add(File.Exists("lib/Uchu.StandardScripts.dll")
+                    ? "lib/Uchu.StandardScripts.dll"
                     : "../../../../Uchu.StandardScripts/bin/Debug/net5.0/Uchu.StandardScripts.dll");
 
                 // Write config file

--- a/Uchu.Master/ServerInstance.cs
+++ b/Uchu.Master/ServerInstance.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using Uchu.Core;
 
 namespace Uchu.Master
@@ -18,24 +19,54 @@ namespace Uchu.Master
         
         public int ApiPort { get; set; }
         
-        public List<ZoneId> Zones { get; set; }
+        public List<ZoneId> Zones { get; set; } = new List<ZoneId>();
         
         public bool Ready { get; set; }
 
         public ServerInstance(Guid id)
         {
             Id = id;
-            
-            Zones = new List<ZoneId>();
         }
 
+        /// <summary>
+        /// Starts the server instance.
+        /// </summary>
+        /// <param name="location">Executable location to use.</param>
+        /// <param name="dotnet">Location of the dotnet command.</param>
         public void Start(string location, string dotnet)
         {
+            // Determine if the dotnet command should be used.
+            // If the default (dotnet) is used, the system PATH is checked.
             var useDotNet = !string.IsNullOrWhiteSpace(dotnet);
+            if (useDotNet && dotnet?.ToLower() == "dotnet" && !File.Exists(dotnet))
+            {
+                var pathDirectories = (Environment.GetEnvironmentVariable("PATH") ?? "").Split(";");
+                var dotNetInPath = pathDirectories.Any(pathDirectory => File.Exists(Path.Combine(pathDirectory, dotnet)));
+                if (!dotNetInPath)
+                {
+                    useDotNet = false;
+                }
+            }
 
+            // Adjust the file name.
+            // If dotnet isn't used, the file name may need to be corrected to have .exe or no extension.
             var file = useDotNet ? dotnet : location;
+            if (!useDotNet && file.ToLower().EndsWith(".dll"))
+            {
+                var parentDirectory = Path.GetDirectoryName(file) ?? "";
+                var baseFileName = Path.GetFileNameWithoutExtension(file);
+                var baseFileLocation = Path.Combine(parentDirectory, baseFileName);
+                if (File.Exists(baseFileLocation + ".exe"))
+                {
+                    file = baseFileLocation + ".exe";
+                } else if (File.Exists(baseFileLocation))
+                {
+                    file = baseFileLocation;
+                }
+            }
             
-            Process = new Process
+            // Create and start the process.
+            this.Process = new Process
             {
                 StartInfo =
                 {
@@ -45,11 +76,10 @@ namespace Uchu.Master
                     RedirectStandardOutput = false,
                     UseShellExecute = true,
                     CreateNoWindow = false,
-                    WindowStyle = ProcessWindowStyle.Normal
+                    WindowStyle = ProcessWindowStyle.Normal,
                 }
             };
-            
-            Process.Start();
+            this.Process.Start();
         }
     }
 }

--- a/Uchu.Master/Uchu.Master.csproj
+++ b/Uchu.Master/Uchu.Master.csproj
@@ -4,6 +4,9 @@
         <OutputType>Exe</OutputType>
         <TargetFramework>net5.0</TargetFramework>
         <LangVersion>8</LangVersion>
+        <BeautyLibsDir>lib</BeautyLibsDir>
+        <NoBeautyFlag>True</NoBeautyFlag>
+        <ForceBeauty>True</ForceBeauty>
     </PropertyGroup>
 
     <ItemGroup>
@@ -11,4 +14,8 @@
       <ProjectReference Include="..\Uchu.Core\Uchu.Core.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <PackageReference Include="nulastudio.NetCoreBeauty" Version="1.2.9.2" />
+    </ItemGroup>
+    
 </Project>

--- a/publish.py
+++ b/publish.py
@@ -48,7 +48,7 @@ for platform in PLATFORMS:
         # Compile the project for the platform.
         print("\tExporting " + project + " for " + platform[0])
 
-        outputDirectory = platformDirectory + (project in DIRECTORY_ADDITIONS.keys() and DIRECTORY_ADDITIONS[project] or "")
+        outputDirectory = platformDirectory + DIRECTORY_ADDITIONS.get(project, "")
         buildParameters = ["dotnet", "publish",
             "--runtime", platform[1],
             "--configuration", "Release",

--- a/publish.py
+++ b/publish.py
@@ -9,6 +9,10 @@ PROJECTS = [
     "Uchu.Instance",
     "Uchu.StandardScripts",
 ]
+DIRECTORY_ADDITIONS = {
+    "Uchu.Instance": "/lib",
+    "Uchu.StandardScripts": "/lib",
+}
 PLATFORMS = [
     ["Windows-x64", "win-x64"],
     ["macOS-x64", "osx-x64"],
@@ -44,18 +48,19 @@ for platform in PLATFORMS:
         # Compile the project for the platform.
         print("\tExporting " + project + " for " + platform[0])
 
+        outputDirectory = platformDirectory + (project in DIRECTORY_ADDITIONS.keys() and DIRECTORY_ADDITIONS[project] or "")
         buildParameters = ["dotnet", "publish",
             "--runtime", platform[1],
             "--configuration", "Release",
-            "--output", platformDirectory,
+            "--output", outputDirectory,
             project + "/" + project + ".csproj"
         ]
         subprocess.call(buildParameters, stdout=open(os.devnull, "w"))
 
         # Clear the unwanted files of the compile.
-        for file in os.listdir(platformDirectory):
-            if file.endswith(".pdb"):
-                os.remove(platformDirectory + "/" + file)
+        for file in os.listdir(outputDirectory):
+            if file.endswith(".pdb") or file.endswith(".bak"):
+                os.remove(outputDirectory + "/" + file)
 
     # Add documentation & license to the output directory.
     for file in ["README.md", "Configuration.md", "LICENSE"]:
@@ -64,4 +69,4 @@ for platform in PLATFORMS:
     # Create the archive.
     print("\tCreating archive for " + platform[0])
     shutil.make_archive("bin/Uchu-" + platform[0], "zip", platformDirectory)
-    shutil.rmtree(platformDirectory)
+    shutil.rmtree(platformDirectory, True)

--- a/publish.py
+++ b/publish.py
@@ -1,5 +1,5 @@
 """
-TheNexusAvenger
+TheNexusAvenger, enteryournamehere
 
 Creates the binaries for distribution.
 """
@@ -43,21 +43,19 @@ for platform in PLATFORMS:
     for project in PROJECTS:
         # Compile the project for the platform.
         print("\tExporting " + project + " for " + platform[0])
-        buildParameters = ["dotnet", "publish", "-r", platform[1], "-c", "Release", project + "/" + project + ".csproj"]
+
+        buildParameters = ["dotnet", "publish",
+            "--runtime", platform[1],
+            "--configuration", "Release",
+            "--output", platformDirectory,
+            project + "/" + project + ".csproj"
+        ]
         subprocess.call(buildParameters, stdout=open(os.devnull, "w"))
 
         # Clear the unwanted files of the compile.
-        dotNetVersion = os.listdir(project + "/bin/Release/")[0]
-        outputDirectory = project + "/bin/Release/" + dotNetVersion + "/" + platform[1] + "/publish"
-        for file in os.listdir(outputDirectory):
+        for file in os.listdir(platformDirectory):
             if file.endswith(".pdb"):
-                os.remove(outputDirectory + "/" + file)
-
-        # Copy the files.
-        for file in os.listdir(outputDirectory):
-            targetLocation = platformDirectory + "/" + file
-            if not os.path.exists(targetLocation):
-                shutil.copy(outputDirectory + "/" + file, targetLocation)
+                os.remove(platformDirectory + "/" + file)
 
     # Create the archive.
     print("\tCreating archive for " + platform[0])

--- a/publish.py
+++ b/publish.py
@@ -1,0 +1,65 @@
+"""
+TheNexusAvenger
+
+Creates the binaries for distribution.
+"""
+
+PROJECTS = [
+    "Uchu.Master",
+    "Uchu.Instance",
+    "Uchu.StandardScripts",
+]
+PLATFORMS = [
+    ["Windows-x64", "win-x64"],
+    ["macOS-x64", "osx-x64"],
+    ["Linux-x64", "linux-x64"],
+]
+
+import os
+import shutil
+import subprocess
+import sys
+
+
+
+# Display a warning for Windows runs.
+if os.name == "nt":
+    sys.stderr.write("Windows was detected. Linux and macOS binaries will be missing the permissions to run.\n")
+
+# Create the directory.
+if os.path.exists("bin"):
+    shutil.rmtree("bin")
+os.mkdir("bin")
+
+# Compile the releases.
+for platform in PLATFORMS:
+    # Create the base directory.
+    print("Building Uchu for " + platform[0])
+    platformDirectory = "bin/Uchu-" + platform[0]
+    if os.path.exists(platformDirectory):
+        shutil.rmtree(platformDirectory)
+    os.mkdir(platformDirectory)
+
+    for project in PROJECTS:
+        # Compile the project for the platform.
+        print("\tExporting " + project + " for " + platform[0])
+        buildParameters = ["dotnet", "publish", "-r", platform[1], "-c", "Release", project + "/" + project + ".csproj"]
+        subprocess.call(buildParameters, stdout=open(os.devnull, "w"))
+
+        # Clear the unwanted files of the compile.
+        dotNetVersion = os.listdir(project + "/bin/Release/")[0]
+        outputDirectory = project + "/bin/Release/" + dotNetVersion + "/" + platform[1] + "/publish"
+        for file in os.listdir(outputDirectory):
+            if file.endswith(".pdb"):
+                os.remove(outputDirectory + "/" + file)
+
+        # Copy the files.
+        for file in os.listdir(outputDirectory):
+            targetLocation = platformDirectory + "/" + file
+            if not os.path.exists(targetLocation):
+                shutil.copy(outputDirectory + "/" + file, targetLocation)
+
+    # Create the archive.
+    print("\tCreating archive for " + platform[0])
+    shutil.make_archive("bin/Uchu-" + platform[0], "zip", platformDirectory)
+    shutil.rmtree(platformDirectory)

--- a/publish.py
+++ b/publish.py
@@ -57,6 +57,10 @@ for platform in PLATFORMS:
             if file.endswith(".pdb"):
                 os.remove(platformDirectory + "/" + file)
 
+    # Add documentation & license to the output directory.
+    for file in ["README.md", "Configuration.md", "LICENSE"]:
+        shutil.copy(file, platformDirectory)
+
     # Create the archive.
     print("\tCreating archive for " + platform[0])
     shutil.make_archive("bin/Uchu-" + platform[0], "zip", platformDirectory)


### PR DESCRIPTION
This pull request attempts to add the last requirements to make releases. The changes include:
* Creating a single publish script for Windows-x64, macOS-x64, and Linux-x64. ARM64 can be added later when .NET 6 releases next year.
  * Releases will need to be made on a non-Windows system to ensure file permissions are correct.
* Checking for `Uchu.Instance.dll` and `Uchu.StandardScripts.dll` in the same directory as `Uchu.Master` for the default configuration.
* Removing the requirement for `dotnet` to be installed for launching servers.
* Disabling Redis by default since we no longer document it or recommend it.