### PR TITLE
Automatically skip Block Yard missions

### DIFF
--- a/Uchu.StandardScripts/AvantGardens/SkipBlockYardMissions.cs
+++ b/Uchu.StandardScripts/AvantGardens/SkipBlockYardMissions.cs
@@ -12,8 +12,8 @@ namespace Uchu.StandardScripts.AvantGardens
     {
         public override Task LoadAsync()
         {
-            var man = Zone.GameObjects.First(g => g.Lot == Lot.CrashHelmutNpc);
-            Listen(man.GetComponent<MissionGiverComponent>().OnMissionOk, async tuple =>
+            var crashHelmut = Zone.GameObjects.First(g => g.Lot == Lot.CrashHelmutNpc);
+            Listen(crashHelmut.GetComponent<MissionGiverComponent>().OnMissionOk, async tuple =>
             {
                 var (missionId, _, _, player) = tuple;
 

--- a/Uchu.StandardScripts/AvantGardens/SkipBlockYardMissions.cs
+++ b/Uchu.StandardScripts/AvantGardens/SkipBlockYardMissions.cs
@@ -1,0 +1,49 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Uchu.Core.Resources;
+using Uchu.World;
+using Uchu.World.Scripting.Native;
+using Uchu.World.Social;
+
+namespace Uchu.StandardScripts.AvantGardens
+{
+    [ZoneSpecific(1100)]
+    public class SkipBlockYardMissions : NativeScript
+    {
+        public override Task LoadAsync()
+        {
+            var man = Zone.GameObjects.First(g => g.Lot == Lot.CrashHelmutNpc);
+            Listen(man.GetComponent<MissionGiverComponent>().OnMissionOk, async tuple =>
+            {
+                var (missionId, _, _, player) = tuple;
+
+                // 'go to block yard' mission
+                if (missionId != (int) MissionId.BackupBulwark)
+                    return;
+
+                // small delay to make sure the mission has been added to the player's mission inventory and started
+                await Task.Delay(1000);
+
+                // complete 'go to block yard' mission
+                var missionInventory = player.GetComponent<MissionInventoryComponent>();
+                var bulwarkMission = missionInventory.GetMission(MissionId.BackupBulwark);
+                await bulwarkMission.CompleteAsync();
+
+                // complete 'smash spider queen' mission
+                var arachnophobiaMission = await missionInventory.AddMissionAsync((int) MissionId.Arachnophobia, player);
+                await arachnophobiaMission.StartAsync();
+                await arachnophobiaMission.CompleteAsync();
+
+                // start 'talk to sky lane' mission
+                var skyLaneMission = await missionInventory.AddMissionAsync((int) MissionId.CheckInwithSkyLane, player);
+                await skyLaneMission.StartAsync();
+
+                // show pop-up to player
+                await UiHelper.AnnouncementAsync((Player) player, "Completed Missions",
+                    "Block Yard is currently not implemented. The missions have been completed for you.");
+            });
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Uchu.StandardScripts/BlockYard/BlockYardWarning.cs
+++ b/Uchu.StandardScripts/BlockYard/BlockYardWarning.cs
@@ -14,7 +14,8 @@ namespace Uchu.StandardScripts.BlockYard
                 await UiHelper.AnnouncementAsync(player, "Not yet implemented",
                     "Block Yard is currently not implemented. You can return to Avant Gardens by sending <font color=\"#FF7F00\">/testmap 1100</font> in the chat.");
             });
-            throw new System.NotImplementedException();
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/Uchu.StandardScripts/BlockYard/BlockYardWarning.cs
+++ b/Uchu.StandardScripts/BlockYard/BlockYardWarning.cs
@@ -1,0 +1,20 @@
+using System.Threading.Tasks;
+using Uchu.World.Scripting.Native;
+using Uchu.World.Social;
+
+namespace Uchu.StandardScripts.BlockYard
+{
+    [ZoneSpecific(1150)]
+    public class BlockYardWarning : NativeScript
+    {
+        public override Task LoadAsync()
+        {
+            Listen(Zone.OnPlayerLoad, async player =>
+            {
+                await UiHelper.AnnouncementAsync(player, "Not yet implemented",
+                    "Block Yard is currently not implemented. You can return to Avant Gardens by sending <font color=\"#FF7F00\">/testmap 1100</font> in the chat.");
+            });
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/Uchu.World/Objects/Components/Player/MissionInventoryComponent.cs
+++ b/Uchu.World/Objects/Components/Player/MissionInventoryComponent.cs
@@ -312,7 +312,7 @@ namespace Uchu.World
         /// <param name="missionId">The missionId to create a mission for</param>
         /// <param name="gameObject">The game object to assign the mission to</param>
         /// <returns>The newly created mission instance</returns>
-        private async Task<MissionInstance> AddMissionAsync(int missionId, GameObject gameObject)
+        public async Task<MissionInstance> AddMissionAsync(int missionId, GameObject gameObject)
         {
             var mission = new MissionInstance(missionId, (Player)GameObject);
             await mission.LoadAsync();

--- a/Uchu.World/Structs/Lot.cs
+++ b/Uchu.World/Structs/Lot.cs
@@ -155,6 +155,8 @@ namespace Uchu.World
         public const int MonumentRaceCancelTrigger = 3297;
         public const int MonumentFinishLine = 4967;
 
+        public const int CrashHelmutNpc = 6374;
+
         #endregion
     }
 }


### PR DESCRIPTION
Makes the process a bit smoother for players. You'll no longer have to type /complete 6 times for a bunch of not-implemented missions. These scripts should be removed when the Spider Queen fight is implemented.