### PR TITLE
Likely fix bug where missions table fails to load

### DIFF
--- a/Uchu.World/Client/CdClient/CacheTable/BurstCacheTable.cs
+++ b/Uchu.World/Client/CdClient/CacheTable/BurstCacheTable.cs
@@ -66,9 +66,9 @@ namespace Uchu.World.Client
 
             // Reset the timer and return the cached entry.
             var result = (this._cachedTable.ContainsKey(index) ? this._cachedTable[index] : Array.Empty<object>()).Cast<T>().ToArray();
-            this._semaphore.Release();
             this._resetTimer.Stop();
             this._resetTimer.Start();
+            this._semaphore.Release();
             return result;
         }
     }


### PR DESCRIPTION
Currently a bug exists where sometimes the Missions table in the cdclient fails to load. This results in `ClientCache.Missions` and `ClientCache.Achievements` being empty, which in turn results in achievements not being completable, and possibly other issues.

This change fixes that bug - it's not entirely clear _why_, or why the issue occurs in the old code, but it seems to work. The old code with a small delay added before `ClientCache.cs:88` (not sure if that's relevant) resulted in the issue occuring 14 out of 25 times, and this new code had it 0 out of 25 times. 