### PR TITLE
Upgrade .NET and EF Core to 6.0, C# to 10

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/Configuration.md
+++ b/Configuration.md
@@ -42,3 +42,7 @@ A Single Sign-On server makes it possible for users to have an account in one si
 ## Server behaviour
 _`<ServerBehaviour>`_  
 If `<PressKeyToExit>` is set to `true`, when the server process exits it will wait for you to press any key. This prevents windows from disappearing too quickly to read an error message.
+
+## Debug options
+_`<Debugging>`_  
+For builds in Debug mode, if `<StartInstanceAsThreads>` is set to `true`, Uchu will use threads instead of separate processes for the different server instances. This makes it possible to use .NET 6's Hot Reload. Support for this mode isn't perfect; logs will no longer include the bit indicating the log source (`[Char]`, `[Auth]` etc.) and the stopping of world won't entirely work as expected.

--- a/Configuration.md
+++ b/Configuration.md
@@ -45,4 +45,4 @@ If `<PressKeyToExit>` is set to `true`, when the server process exits it will wa
 
 ## Debug options
 _`<Debugging>`_  
-For builds in Debug mode, if `<StartInstanceAsThreads>` is set to `true`, Uchu will use threads instead of separate processes for the different server instances. This makes it possible to use .NET 6's Hot Reload. Support for this mode isn't perfect; logs will no longer include the bit indicating the log source (`[Char]`, `[Auth]` etc.) and the stopping of world won't entirely work as expected.
+For builds in Debug mode, if `<StartInstancesAsThreads>` is set to `true`, Uchu will use threads instead of separate processes for the different server instances. This makes it possible to use .NET 6's Hot Reload. Support for this mode isn't perfect; logs will no longer include the bit indicating the log source (`[Char]`, `[Auth]` etc.) and the stopping of world won't entirely work as expected.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Whenever you run Uchu Tool, it will automatically check for updates and (when ap
 In this section it is assumed that you are familiar with your operating system's terminal emulator, and know how to use it to navigate to folders and run files.
 
 - Install [git](https://git-scm.com/downloads)
-- Install [.NET 5.0 SDK](https://dotnet.microsoft.com/download) (for Linux users it will be called `.NET` without `SDK`)
+- Install [.NET 6.0 SDK](https://dotnet.microsoft.com/download) (for Linux users it will be called `.NET` without `SDK`)
 
 **Clone the repository:**
 ```bash
@@ -79,7 +79,7 @@ dotnet build
 
 **Start the server:**
 ```bash
-cd Uchu.Master/bin/Debug/net5.0
+cd Uchu.Master/bin/Debug/net6.0
 dotnet Uchu.Master.dll
 ```
 

--- a/Uchu.Api/Uchu.Api.csproj
+++ b/Uchu.Api/Uchu.Api.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Uchu.Auth/Uchu.Auth.csproj
+++ b/Uchu.Auth/Uchu.Auth.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>10</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Uchu.Auth/Uchu.Auth.csproj
+++ b/Uchu.Auth/Uchu.Auth.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
-        <LangVersion>8</LangVersion>
+        <TargetFramework>net6.0</TargetFramework>
+        <LangVersion>10</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>
@@ -10,7 +10,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.5" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />
     </ItemGroup>
 
 </Project>

--- a/Uchu.Char/Uchu.Char.csproj
+++ b/Uchu.Char/Uchu.Char.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>10</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Uchu.Char/Uchu.Char.csproj
+++ b/Uchu.Char/Uchu.Char.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
-        <LangVersion>8</LangVersion>
+        <TargetFramework>net6.0</TargetFramework>
+        <LangVersion>10</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Uchu.Core.Test/Uchu.Core.Test.csproj
+++ b/Uchu.Core.Test/Uchu.Core.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/Uchu.Core/Config/UchuConfiguration.cs
+++ b/Uchu.Core/Config/UchuConfiguration.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using System.Xml;
 using System.Xml.Serialization;
 using Microsoft.Extensions.Logging;
@@ -110,9 +111,9 @@ namespace Uchu.Core.Config
         /// <param name="path">File to save to.</param>
         public void Save(string path)
         {
-            using var file = File.CreateText(path);
-            Serializer.Serialize(file, this);
-            file.Close();
+            using var streamWriter = new XmlTextWriter(path, Encoding.UTF8);
+            streamWriter.Formatting = Formatting.Indented;
+            Serializer.Serialize(streamWriter, this);
         }
 
         /// <summary>
@@ -186,7 +187,7 @@ namespace Uchu.Core.Config
         /// <summary>
         /// The path to the Uchu.Instance DLL
         /// </summary>
-        [XmlElement] public string Instance { get; set; } = "../../../../Uchu.Instance/bin/Debug/net5.0/Uchu.Instance.dll";
+        [XmlElement] public string Instance { get; set; } = "../../../../Uchu.Instance/bin/Debug/net6.0/Uchu.Instance.dll";
 
         /// <summary>
         /// Whether to use threads instead of processes. Only available for builds in Debug mode.

--- a/Uchu.Core/Config/UchuConfiguration.cs
+++ b/Uchu.Core/Config/UchuConfiguration.cs
@@ -102,6 +102,11 @@ namespace Uchu.Core.Config
         /// General behaviour of the program
         /// </summary>
         [XmlElement("ServerBehaviour")] public ServerBehaviour ServerBehaviour { get; set; } = new ServerBehaviour();
+        
+        /// <summary>
+        /// Options for development and debugging
+        /// </summary>
+        [XmlElement("Debugging")] public DebugConfig DebugConfig { get; set; } = new DebugConfig();
 
         private static readonly XmlSerializer Serializer = new XmlSerializer(typeof(UchuConfiguration));
 
@@ -188,11 +193,6 @@ namespace Uchu.Core.Config
         /// The path to the Uchu.Instance DLL
         /// </summary>
         [XmlElement] public string Instance { get; set; } = "../../../../Uchu.Instance/bin/Debug/net6.0/Uchu.Instance.dll";
-
-        /// <summary>
-        /// Whether to use threads instead of processes. Only available for builds in Debug mode.
-        /// </summary>
-        [XmlElement] public bool StartInstancesAsThreads { get; set; } = false;
 
         /// <summary>
         /// The path to the script source DLLs
@@ -388,5 +388,16 @@ namespace Uchu.Core.Config
         /// How long the server should wait for newly created instances to get ready before throwing a timeout exception
         /// </summary>
         [XmlElement] public int InstanceCommissionTimeout { get; set; } = 30000;
+    }
+
+    /// <summary>
+    /// Options for development and debugging
+    /// </summary>
+    public class DebugConfig
+    {
+        /// <summary>
+        /// Whether to use threads instead of processes. Only available for builds in Debug mode.
+        /// </summary>
+        [XmlElement] public bool StartInstancesAsThreads { get; set; } = false;
     }
 }

--- a/Uchu.Core/Config/UchuConfiguration.cs
+++ b/Uchu.Core/Config/UchuConfiguration.cs
@@ -187,7 +187,12 @@ namespace Uchu.Core.Config
         /// The path to the Uchu.Instance DLL
         /// </summary>
         [XmlElement] public string Instance { get; set; } = "../../../../Uchu.Instance/bin/Debug/net5.0/Uchu.Instance.dll";
-        
+
+        /// <summary>
+        /// Whether to use threads instead of processes. Only available for builds in Debug mode.
+        /// </summary>
+        [XmlElement] public bool StartInstancesAsThreads { get; set; } = false;
+
         /// <summary>
         /// The path to the script source DLLs
         /// </summary>

--- a/Uchu.Core/Uchu.Core.csproj
+++ b/Uchu.Core/Uchu.Core.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
-        <LangVersion>8</LangVersion>
+        <TargetFramework>net6.0</TargetFramework>
+        <LangVersion>10</LangVersion>
         <NeutralLanguage>en</NeutralLanguage>
     </PropertyGroup>
 
@@ -12,13 +12,13 @@
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.5">
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.0">
         <PrivateAssets>all</PrivateAssets>
         <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       </PackageReference>
-      <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.5" />
-      <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="5.0.0" />
-      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="5.0.5.1" />
+      <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="6.0.0" />
+      <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="6.0.0" />
+      <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="6.0.0" />
       <PackageReference Include="Sentry" Version="3.0.6" />
       <PackageReference Include="StackExchange.Redis" Version="2.1.0-preview.23" />
     </ItemGroup>

--- a/Uchu.Core/Uchu.Core.csproj
+++ b/Uchu.Core/Uchu.Core.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>10</LangVersion>
         <NeutralLanguage>en</NeutralLanguage>
     </PropertyGroup>
 

--- a/Uchu.Core/UchuServer.cs
+++ b/Uchu.Core/UchuServer.cs
@@ -203,7 +203,8 @@ namespace Uchu.Core
                 using (var xmlReader = XmlReader.Create(fs))
                 {
                     Config = (UchuConfiguration) serializer.Deserialize(xmlReader);
-                    Logger.SetConfiguration(Config);
+                    if (!Config.DllSource.StartInstancesAsThreads)
+                        Logger.SetConfiguration(Config);
                     UchuContextBase.Config = Config;
                 }
             }

--- a/Uchu.Core/UchuServer.cs
+++ b/Uchu.Core/UchuServer.cs
@@ -203,7 +203,7 @@ namespace Uchu.Core
                 using (var xmlReader = XmlReader.Create(fs))
                 {
                     Config = (UchuConfiguration) serializer.Deserialize(xmlReader);
-                    if (!Config.DllSource.StartInstancesAsThreads)
+                    if (!Config.DebugConfig.StartInstancesAsThreads)
                         Logger.SetConfiguration(Config);
                     UchuContextBase.Config = Config;
                 }

--- a/Uchu.Instance/Program.cs
+++ b/Uchu.Instance/Program.cs
@@ -48,14 +48,14 @@ namespace Uchu.Instance
                 {
                     case ServerType.Authentication:
 #if DEBUG
-                        if (!UchuServer.Config.DllSource.StartInstancesAsThreads)
+                        if (!UchuServer.Config.DebugConfig.StartInstancesAsThreads)
 #endif
                             Logger.SetServerTypeInformation("Auth");
                         await UchuServer.StartAsync(typeof(LoginHandler).Assembly, true);
                         break;
                     case ServerType.Character:
 #if DEBUG
-                        if (!UchuServer.Config.DllSource.StartInstancesAsThreads)
+                        if (!UchuServer.Config.DebugConfig.StartInstancesAsThreads)
 #endif
                             Logger.SetServerTypeInformation("Char");
                         await UchuServer.StartAsync(typeof(CharacterHandler).Assembly);

--- a/Uchu.Instance/Program.cs
+++ b/Uchu.Instance/Program.cs
@@ -15,15 +15,22 @@ using Uchu.World.Handlers;
 
 namespace Uchu.Instance
 {
-    internal static class Program
+    public class Program
     {
-        private static UchuServer UchuServer { get; set; }
-        
-        private static Guid Id { get; set; }
-        
-        private static ServerType ServerType { get; set; }
-        
-        private static async Task Main(string[] args)
+        private UchuServer UchuServer { get; set; }
+
+        private Guid Id { get; set; }
+
+        private ServerType ServerType { get; set; }
+
+        public static async Task Main(string[] args)
+        {
+            var server = new Program();
+
+            await server.Start(args);
+        }
+
+        public async Task Start(string[] args)
         {
             if (args.Length != 2)
                 throw new ArgumentException("Expected 2 argument.");
@@ -40,11 +47,17 @@ namespace Uchu.Instance
                 switch (ServerType)
                 {
                     case ServerType.Authentication:
-                        Logger.SetServerTypeInformation("Auth");
+#if DEBUG
+                        if (!UchuServer.Config.DllSource.StartInstancesAsThreads)
+#endif
+                            Logger.SetServerTypeInformation("Auth");
                         await UchuServer.StartAsync(typeof(LoginHandler).Assembly, true);
                         break;
                     case ServerType.Character:
-                        Logger.SetServerTypeInformation("Char");
+#if DEBUG
+                        if (!UchuServer.Config.DllSource.StartInstancesAsThreads)
+#endif
+                            Logger.SetServerTypeInformation("Char");
                         await UchuServer.StartAsync(typeof(CharacterHandler).Assembly);
                         break;
                     case ServerType.World:
@@ -77,7 +90,7 @@ namespace Uchu.Instance
             Console.ReadKey();
         }
 
-        private static async Task ConfigureAsync(string config)
+        private async Task ConfigureAsync(string config)
         {
             var serializer = new XmlSerializer(typeof(UchuConfiguration));
 

--- a/Uchu.Instance/Uchu.Instance.csproj
+++ b/Uchu.Instance/Uchu.Instance.csproj
@@ -3,7 +3,6 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>10</LangVersion>
         <RootNamespace>Uchu.Instance</RootNamespace>
     </PropertyGroup>
 

--- a/Uchu.Instance/Uchu.Instance.csproj
+++ b/Uchu.Instance/Uchu.Instance.csproj
@@ -2,8 +2,8 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net5.0</TargetFramework>
-        <LangVersion>8</LangVersion>
+        <TargetFramework>net6.0</TargetFramework>
+        <LangVersion>10</LangVersion>
         <RootNamespace>Uchu.Instance</RootNamespace>
     </PropertyGroup>
 

--- a/Uchu.Master/Api/MasterCommands.cs
+++ b/Uchu.Master/Api/MasterCommands.cs
@@ -274,7 +274,7 @@ namespace Uchu.Master.Api
                 return response;
             }
 
-            instance.Process.Kill();
+            instance.Process?.Kill();
 
             instances.Remove(instance);
 

--- a/Uchu.Master/MasterServer.cs
+++ b/Uchu.Master/MasterServer.cs
@@ -180,7 +180,7 @@ namespace Uchu.Master
 
             foreach (var instance in Instances)
             {
-                instance.Process.Kill();
+                instance.Process?.Kill();
             }
 
             if (!(ev is ConsoleCancelEventArgs cancelEv)) return;
@@ -323,21 +323,30 @@ namespace Uchu.Master
             {
                 Config = UchuConfiguration.Load(configFilename);
                 Logger.SetConfiguration(Config);
-                Logger.SetServerTypeInformation("Master");
+#if DEBUG
+                if (!Config.DllSource.StartInstancesAsThreads)
+#endif
+                    Logger.SetServerTypeInformation("Master");
             }
             // Otherwise, use config.default.xml if it exists
             else if (File.Exists(legacySecondConfigName))
             {
                 Config = UchuConfiguration.Load(legacySecondConfigName);
                 Logger.SetConfiguration(Config);
-                Logger.SetServerTypeInformation("Master");
+#if DEBUG
+                if (!Config.DllSource.StartInstancesAsThreads)
+#endif
+                    Logger.SetServerTypeInformation("Master");
             }
             // Otherwise, generate a new config file
             else
             {
                 Config = new UchuConfiguration();
                 Logger.SetConfiguration(Config);
-                Logger.SetServerTypeInformation("Master");
+#if DEBUG
+                if (!Config.DllSource.StartInstancesAsThreads)
+#endif
+                    Logger.SetServerTypeInformation("Master");
 
                 // Add default value for instance DLL source and script DLL source.
                 if (File.Exists("lib/Uchu.Instance.dll"))

--- a/Uchu.Master/MasterServer.cs
+++ b/Uchu.Master/MasterServer.cs
@@ -324,7 +324,7 @@ namespace Uchu.Master
                 Config = UchuConfiguration.Load(configFilename);
                 Logger.SetConfiguration(Config);
 #if DEBUG
-                if (!Config.DllSource.StartInstancesAsThreads)
+                if (!Config.DebugConfig.StartInstancesAsThreads)
 #endif
                     Logger.SetServerTypeInformation("Master");
             }
@@ -334,7 +334,7 @@ namespace Uchu.Master
                 Config = UchuConfiguration.Load(legacySecondConfigName);
                 Logger.SetConfiguration(Config);
 #if DEBUG
-                if (!Config.DllSource.StartInstancesAsThreads)
+                if (!Config.DebugConfig.StartInstancesAsThreads)
 #endif
                     Logger.SetServerTypeInformation("Master");
             }
@@ -344,7 +344,7 @@ namespace Uchu.Master
                 Config = new UchuConfiguration();
                 Logger.SetConfiguration(Config);
 #if DEBUG
-                if (!Config.DllSource.StartInstancesAsThreads)
+                if (!Config.DebugConfig.StartInstancesAsThreads)
 #endif
                     Logger.SetServerTypeInformation("Master");
 

--- a/Uchu.Master/MasterServer.cs
+++ b/Uchu.Master/MasterServer.cs
@@ -355,7 +355,7 @@ namespace Uchu.Master
                 }
                 Config.DllSource.ScriptDllSource.Add(File.Exists("lib/Uchu.StandardScripts.dll")
                     ? "lib/Uchu.StandardScripts.dll"
-                    : "../../../../Uchu.StandardScripts/bin/Debug/net5.0/Uchu.StandardScripts.dll");
+                    : "../../../../Uchu.StandardScripts/bin/Debug/net6.0/Uchu.StandardScripts.dll");
 
                 // Write config file
                 Config.Save(configFilename);
@@ -392,6 +392,13 @@ namespace Uchu.Master
             }
 
             // Check: Uchu.Instance.dll
+            // Migration from .net 5 to .net 6
+            if (Config.DllSource.Instance.Contains("net5.0"))
+            {
+                Config.DllSource.Instance = Config.DllSource.Instance.Replace("net5.0", "net6.0");
+                Config.Save(configFilename);
+            }
+
             DllLocation = Config.DllSource.Instance;
 
             if (!File.Exists(DllLocation))
@@ -402,17 +409,24 @@ namespace Uchu.Master
             // Check: Uchu.StandardScripts.dll
             var validScriptPackExists = false;
 
-            Config.DllSource.ScriptDllSource.ForEach(scriptPackPath =>
+            for (var i = 0; i < Config.DllSource.ScriptDllSource.Count; i++)
             {
-                if (File.Exists(scriptPackPath))
+                // Migration from .net 5 to .net 6
+                if (Config.DllSource.ScriptDllSource[i].Contains("net5.0"))
                 {
-                    Logger.Information($"Using script pack: {scriptPackPath}");
-                    validScriptPackExists = true;
-                    return;
+                    Config.DllSource.ScriptDllSource[i] = Config.DllSource.ScriptDllSource[i].Replace("net5.0", "net6.0");
+                    Config.Save(configFilename);
                 }
 
-                Logger.Warning($"Could not find script pack at {scriptPackPath}");
-            });
+                if (File.Exists(Config.DllSource.ScriptDllSource[i]))
+                {
+                    Logger.Information($"Using script pack: {Config.DllSource.ScriptDllSource[i]}");
+                    validScriptPackExists = true;
+                    break;
+                }
+
+                Logger.Warning($"Could not find script pack at {Config.DllSource.ScriptDllSource[i]}");
+            }
 
             if (!validScriptPackExists)
             {

--- a/Uchu.Master/ServerInstance.cs
+++ b/Uchu.Master/ServerInstance.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+#if DEBUG
+using System.Threading;
+#endif
 using Uchu.Core;
 
 namespace Uchu.Master
@@ -35,6 +38,27 @@ namespace Uchu.Master
         /// <param name="dotnet">Location of the dotnet command.</param>
         public void Start(string location, string dotnet)
         {
+#if DEBUG
+            if (MasterServer.Config.DllSource.StartInstancesAsThreads)
+                this.StartInstanceAsThread();
+            else
+#endif
+                this.StartInstanceAsProcess(location, dotnet);
+        }
+
+#if DEBUG
+        public void StartInstanceAsThread()
+        {
+            new Thread(() =>
+            {
+                var program = new Uchu.Instance.Program();
+                program.Start(new[] { Id.ToString(), MasterServer.ConfigPath });
+            }).Start();
+        }
+#endif
+
+        public void StartInstanceAsProcess(string location, string dotnet)
+            {
             // Determine if the dotnet command should be used.
             // If the default (dotnet) is used, the system PATH is checked.
             var useDotNet = !string.IsNullOrWhiteSpace(dotnet);

--- a/Uchu.Master/ServerInstance.cs
+++ b/Uchu.Master/ServerInstance.cs
@@ -39,7 +39,7 @@ namespace Uchu.Master
         public void Start(string location, string dotnet)
         {
 #if DEBUG
-            if (MasterServer.Config.DllSource.StartInstancesAsThreads)
+            if (MasterServer.Config.DebugConfig.StartInstancesAsThreads)
                 this.StartInstanceAsThread();
             else
 #endif

--- a/Uchu.Master/Uchu.Master.csproj
+++ b/Uchu.Master/Uchu.Master.csproj
@@ -12,6 +12,7 @@
     <ItemGroup>
       <ProjectReference Include="..\Uchu.Api\Uchu.Api.csproj" />
       <ProjectReference Include="..\Uchu.Core\Uchu.Core.csproj" />
+      <ProjectReference Include="..\Uchu.Instance\Uchu.Instance.csproj" Condition="'$(Configuration)' == 'Debug'"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/Uchu.Master/Uchu.Master.csproj
+++ b/Uchu.Master/Uchu.Master.csproj
@@ -2,8 +2,8 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net5.0</TargetFramework>
-        <LangVersion>8</LangVersion>
+        <TargetFramework>net6.0</TargetFramework>
+        <LangVersion>10</LangVersion>
         <BeautyLibsDir>lib</BeautyLibsDir>
         <NoBeautyFlag>True</NoBeautyFlag>
         <ForceBeauty>True</ForceBeauty>

--- a/Uchu.Master/Uchu.Master.csproj
+++ b/Uchu.Master/Uchu.Master.csproj
@@ -3,7 +3,6 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>10</LangVersion>
         <BeautyLibsDir>lib</BeautyLibsDir>
         <NoBeautyFlag>True</NoBeautyFlag>
         <ForceBeauty>True</ForceBeauty>

--- a/Uchu.Navigation/Uchu.Navigation.csproj
+++ b/Uchu.Navigation/Uchu.Navigation.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
 </Project>

--- a/Uchu.Physics.Test/Uchu.Physics.Test.csproj
+++ b/Uchu.Physics.Test/Uchu.Physics.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <OutputType>Exe</OutputType>
     </PropertyGroup>
 

--- a/Uchu.Physics/Uchu.Physics.csproj
+++ b/Uchu.Physics/Uchu.Physics.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Uchu.Python/Uchu.Python.csproj
+++ b/Uchu.Python/Uchu.Python.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Uchu.Sso/Uchu.Sso.csproj
+++ b/Uchu.Sso/Uchu.Sso.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
 </Project>

--- a/Uchu.StandardScripts/Uchu.StandardScripts.csproj
+++ b/Uchu.StandardScripts/Uchu.StandardScripts.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>10</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Uchu.StandardScripts/Uchu.StandardScripts.csproj
+++ b/Uchu.StandardScripts/Uchu.StandardScripts.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
-        <LangVersion>8</LangVersion>
+        <TargetFramework>net6.0</TargetFramework>
+        <LangVersion>10</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Uchu.World.Test/Uchu.World.Test.csproj
+++ b/Uchu.World.Test/Uchu.World.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
 
         <IsPackable>false</IsPackable>
     </PropertyGroup>

--- a/Uchu.World/Uchu.World.csproj
+++ b/Uchu.World/Uchu.World.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net5.0</TargetFramework>
-        <LangVersion>8</LangVersion>
+        <TargetFramework>net6.0</TargetFramework>
+        <LangVersion>10</LangVersion>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     </PropertyGroup>
 

--- a/Uchu.World/Uchu.World.csproj
+++ b/Uchu.World/Uchu.World.csproj
@@ -2,7 +2,6 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
-        <LangVersion>10</LangVersion>
         <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     </PropertyGroup>
 

--- a/Uchu.World/WorldUchuServer.cs
+++ b/Uchu.World/WorldUchuServer.cs
@@ -79,7 +79,10 @@ namespace Uchu.World
             ).ConfigureAwait(false);
 
             ZoneId = (ZoneId) instance.Info.Zones.First();
-            Logger.SetServerTypeInformation("Z" + ZoneId.Id);
+#if DEBUG
+            if (!Config.DllSource.StartInstancesAsThreads)
+#endif
+                Logger.SetServerTypeInformation("Z" + ZoneId.Id);
 
             var info = await Api.RunCommandAsync<InstanceInfoResponse>(MasterApi, $"instance/target?i={Id}");
 

--- a/Uchu.World/WorldUchuServer.cs
+++ b/Uchu.World/WorldUchuServer.cs
@@ -80,7 +80,7 @@ namespace Uchu.World
 
             ZoneId = (ZoneId) instance.Info.Zones.First();
 #if DEBUG
-            if (!Config.DllSource.StartInstancesAsThreads)
+            if (!Config.DebugConfig.StartInstancesAsThreads)
 #endif
                 Logger.SetServerTypeInformation("Z" + ZoneId.Id);
 


### PR DESCRIPTION
As the title says!
Additionally: you can now run server instances as threads instead of separate processes, making it possible to take advantage of .NET 6's Hot Reload functionality to make code modifications while the program is running.
To do this, build in Debug mode (in Release mode, Uchu.Master won't reference Uchu.Instance) and set `DllSource`->`StartInstancesAsThreads` to `true` in the config. (Maybe this isn't the ideal location for this config variable. I put it here so that it's right below `Instance`, but feel free to suggest another place.)
Support for running instances as threads isn't perfect (I think the "auto-shutdown inactive worlds" functionality won't work, and console output won't have the indicator of the source (`[Auth]`, `[Char]`, etc)), but it should be good enough for development purposes.