### PR TITLE
New Verify API | Changed "account/list"

### DIFF
--- a/Uchu.Api/API.md
+++ b/Uchu.Api/API.md
@@ -31,7 +31,7 @@ By default, Uchu will have its API available on ports `10000 and up`. If you wan
 | `account/ban` | Takes in a `username` and a `reason`, and bans the account with that `username`. | http://localhost:10000/account/ban?= `username`&`reason` | `username`, `reason`
 | `account/pardon` | Takes in a `username`, and pardons the account with that `username`. | http://localhost:10000/account/pardon?= `username` | `username`
 | `account/info` | Takes in a `username`, and returns information about the account with that `username`.  | http://localhost:10000/account/info?= `username` | `username`
-| `account/list` | Returns the `id` of all created accounts. | http://localhost:10000/account/list | None
+| `account/list` | Returns the `username` of all created accounts. | http://localhost:10000/account/list | None
 
 ## Character options
 

--- a/Uchu.Api/API.md
+++ b/Uchu.Api/API.md
@@ -25,6 +25,7 @@ By default, Uchu will have its API available on ports `10000 and up`. If you wan
 | Name | Description | Example | Expected Values |
 |-|-|-|-|
 | `account/new` | Takes in a `username` and `password`, and creates an account with those credentials. | http://localhost:10000/account/new?= `username`&`password` | `username`, `password` |
+| `account/verify` | Takes in a `username` and `password`, and verifies the password hash. | http://localhost:10000/account/verify?= `username`&`password` | `username`, `password` |
 | `account/delete` | Takes in a `username`, and deletes the account with that `username`. | http://localhost:10000/account/delete?= `username` | `username` |
 | `account/level` | Takes in a `username` and a `level`, and sets the account with that `username` to that game master level. | http://localhost:10000/account/level?= `username`&`level` | `username`, `1,2,6,9` 
 | `account/ban` | Takes in a `username` and a `reason`, and bans the account with that `username`. | http://localhost:10000/account/ban?= `username`&`reason` | `username`, `reason`

--- a/Uchu.Api/ApiManager.cs
+++ b/Uchu.Api/ApiManager.cs
@@ -20,6 +20,8 @@ namespace Uchu.Api
         public string Domain { get; }
         
         public int Port { get; private set; }
+
+        private string _key;
         
         public Dictionary<string, (MethodInfo, object)> Map { get; }
 
@@ -27,7 +29,7 @@ namespace Uchu.Api
 
         private bool _running;
 
-        public ApiManager(string protocol, string domain)
+        public ApiManager(string protocol, string domain, string key)
         {
             Listener = new HttpListener();
 
@@ -36,6 +38,8 @@ namespace Uchu.Api
             Protocol = protocol;
 
             Domain = domain;
+
+            _key = key;
         }
 
         public async Task StartAsync(int port)
@@ -84,9 +88,9 @@ namespace Uchu.Api
                     {
                         var contents = request.Headers.Get("X-Uchu-Token");
 
-                        Console.WriteLine(contents == "pu76QkecNwW7bzbaQtQzSF4URc9VGY4sLqJEvuXu");
+                        Console.WriteLine(contents == _key);
                         
-                        if (contents == "pu76QkecNwW7bzbaQtQzSF4URc9VGY4sLqJEvuXu")
+                        if (contents == _key)
                         {
                             Console.WriteLine("Message if Header is present " + contents);
                             // if correct continue, otherwise return 403 response

--- a/Uchu.Api/Models/AccountListResponse.cs
+++ b/Uchu.Api/Models/AccountListResponse.cs
@@ -4,6 +4,6 @@ namespace Uchu.Api.Models
 {
     public class AccountListResponse : BaseResponse
     {
-        public List<long> Accounts { get; set; }
+        public List<string> Accounts { get; set; }
     }
 }

--- a/Uchu.Api/Models/AccountVerifyResponse.cs
+++ b/Uchu.Api/Models/AccountVerifyResponse.cs
@@ -5,5 +5,7 @@ namespace Uchu.Api.Models
         public string Username { get; set; }
 
         public bool VerifiedPassword { get; set; }
+
+        public string Key { get; set; }
     }
 }

--- a/Uchu.Api/Models/AccountVerifyResponse.cs
+++ b/Uchu.Api/Models/AccountVerifyResponse.cs
@@ -1,0 +1,9 @@
+namespace Uchu.Api.Models
+{
+    public class AccountVerifyResponse : BaseResponse
+    {
+        public string Username { get; set; }
+
+        public bool VerifiedPassword { get; set; }
+    }
+}

--- a/Uchu.Core/Config/UchuConfiguration.cs
+++ b/Uchu.Core/Config/UchuConfiguration.cs
@@ -293,6 +293,11 @@ namespace Uchu.Core.Config
         /// The port to run the API on
         /// </summary>
         [XmlElement] public int Port { get; set; } = 10000;
+
+        /// <summary>
+        /// The key to access the API
+        /// </summary>
+        [XmlElement] public string Key { get; set; } = "";
     }
 
     /// <summary>

--- a/Uchu.Core/UchuServer.cs
+++ b/Uchu.Core/UchuServer.cs
@@ -263,7 +263,7 @@ namespace Uchu.Core
         /// <exception cref="Exception">An exception if the setup of the API failed</exception>
         public async Task SetupApiAsync()
         {
-            Api = new ApiManager(Config.ApiConfig.Protocol, Config.ApiConfig.Domain);
+            Api = new ApiManager(Config.ApiConfig.Protocol, Config.ApiConfig.Domain, Config.ApiConfig.Key);
 
             var instance = await Api.RunCommandAsync<InstanceInfoResponse>(
                 Config.ApiConfig.Port, $"instance/target?i={Id}"

--- a/Uchu.Instance/Program.cs
+++ b/Uchu.Instance/Program.cs
@@ -110,7 +110,7 @@ namespace Uchu.Instance
 
             SqliteContext.DatabasePath = Path.Combine(masterPath, "./Uchu.sqlite");
 
-            var api = new ApiManager(uchuConfiguration.ApiConfig.Protocol, uchuConfiguration.ApiConfig.Domain);
+            var api = new ApiManager(uchuConfiguration.ApiConfig.Protocol, uchuConfiguration.ApiConfig.Domain, uchuConfiguration.ApiConfig.Key);
 
             var instance = await api.RunCommandAsync<InstanceInfoResponse>(
                 uchuConfiguration.ApiConfig.Port, $"instance/target?i={Id}"

--- a/Uchu.Master/Api/AccountCommands.cs
+++ b/Uchu.Master/Api/AccountCommands.cs
@@ -5,11 +5,14 @@ using Microsoft.EntityFrameworkCore;
 using Uchu.Api;
 using Uchu.Api.Models;
 using Uchu.Core;
+using Uchu.Core.Config;
 
 namespace Uchu.Master.Api
 {
     public class AccountCommands
     {
+        public static UchuConfiguration Config { get; set; }
+
         [ApiCommand("account/new")]
         public async Task<object> CreateAccount(string accountName, string accountPassword)
         {
@@ -99,9 +102,11 @@ namespace Uchu.Master.Api
                 var EnhancedHashPassword = user.Password;
                 var VerifiedPassword = BCrypt.Net.BCrypt.EnhancedVerify(accountPassword, EnhancedHashPassword);
 
+                var Key = "test";
                 response.Success = true;
                 response.Username = user.Username;
                 response.VerifiedPassword = VerifiedPassword;
+                response.Key = Key;
             }
 
             return response;

--- a/Uchu.Master/Api/AccountCommands.cs
+++ b/Uchu.Master/Api/AccountCommands.cs
@@ -11,7 +11,7 @@ namespace Uchu.Master.Api
 {
     public class AccountCommands
     {
-        public static UchuConfiguration Config { get; set; }
+        public UchuConfiguration Config { get; set; }
 
         [ApiCommand("account/new")]
         public async Task<object> CreateAccount(string accountName, string accountPassword)
@@ -72,6 +72,8 @@ namespace Uchu.Master.Api
         [ApiCommand("account/verify")]
         public async Task<object> VerifyAccount(string accountName, string accountPassword)
         {
+            var config = new UchuConfiguration();
+
             var response = new AccountVerifyResponse();
 
             if (string.IsNullOrWhiteSpace(accountName))
@@ -102,11 +104,17 @@ namespace Uchu.Master.Api
                 var EnhancedHashPassword = user.Password;
                 var VerifiedPassword = BCrypt.Net.BCrypt.EnhancedVerify(accountPassword, EnhancedHashPassword);
 
-                var Key = "test";
+                if (VerifiedPassword == false)
+                {
+                    response.FailedReason = "password wrong";
+
+                    return response;
+                }
+
                 response.Success = true;
                 response.Username = user.Username;
                 response.VerifiedPassword = VerifiedPassword;
-                response.Key = Key;
+                response.Key = config.ApiConfig.Key;
             }
 
             return response;

--- a/Uchu.Master/MasterServer.cs
+++ b/Uchu.Master/MasterServer.cs
@@ -194,7 +194,7 @@ namespace Uchu.Master
         {
             var apiConfig = Config.ApiConfig;
 
-            Api = new ApiManager(apiConfig.Protocol, apiConfig.Domain);
+            Api = new ApiManager(apiConfig.Protocol, apiConfig.Domain, apiConfig.Key);
             
             Api.RegisterCommandCollection<AccountCommands>();
             


### PR DESCRIPTION
These changes add the functionality to create a web-app for users / administrators to login and manage the servers.
	
Tasks:
- [x] Add API to verify password
- [x] Change output of `account/list` call `usernames` instead of `ids`
- [ ] Add API Key in `Header` to instances
	- [ ] Instances can't connect to master server due to missing api key in header
- [x] Deny access to api calls without key
- [x] Exception for /verify
	- [x] Respond with 401 if no key
	- [x] Verify Response
		- [ ] Respond with key from `config.xml`
- [x] Add New XmlElement `Key` to UchuConfiguration
	- [x] Add `Key` from `config.xml` to `ApiManager.cs`
	- [ ] Add `Key` from `config.xml` to `AccountCommands.cs`
- [x] Set `Access-Control-Allow-Origin, *` for all responses
- [ ] Fix https protocol not working
	- [ ] All instances stop working if changing `http` to `https` in `config.xml`