### PR TITLE
Fix Achievement Progression Issues with Multiple Task Types

### DIFF
--- a/Uchu.World/Objects/Components/Player/MissionInventoryComponent.cs
+++ b/Uchu.World/Objects/Components/Player/MissionInventoryComponent.cs
@@ -787,7 +787,8 @@ namespace Uchu.World
 
                 foreach (var task in mission.Tasks)
                 {
-                    await progress(task as T);
+                    if (!(task is T instance)) continue;
+                    await progress(instance);
                 }
             }
         }


### PR DESCRIPTION
Fixes #260

This pull request resolves an issue with `StartUnlockableAchievementsAsync` where null objects would be passed. This is due to a behavior with casing using `as` making the value `null` if the type is incorrect. This affects missions like "Pirate Legend" which involves a Smash task, Script task (...because of course...), and Obtain Item task. Combinations like this would result in the `progress` callback being called with `null` values, leading to an exception when trying to progress a `null` mission task.