### PR TITLE
Add Crux Prime Enemy Spawning

### DIFF
--- a/Uchu.StandardScripts/CruxPrime/RandomSpawnerBase.cs
+++ b/Uchu.StandardScripts/CruxPrime/RandomSpawnerBase.cs
@@ -1,0 +1,303 @@
+using System;
+using System.Collections.Generic;
+using Uchu.World;
+using Uchu.World.Scripting.Native;
+
+namespace Uchu.StandardScripts.CruxPrime
+{
+    /// <summary>
+    /// Struct for storing the spawn information in a zone part.
+    /// </summary>
+    public struct RandomSpawnerZoneEntry
+    {
+        /// <summary>
+        /// LOT of the enemies to spawn.
+        /// </summary>
+        public Lot Lot { get; set; }
+        
+        /// <summary>
+        /// Number of the enemies to spawn.
+        /// </summary>
+        public int Number { get; set; }
+        
+        /// <summary>
+        /// Name used with the spawner.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Creates the zone entry.
+        /// </summary>
+        /// <param name="lot">Lot of the enemies to spawn.</param>
+        /// <param name="number">Number of the enemies to spawn.</param>
+        /// <param name="name">Name used with the spawner.</param>
+        public RandomSpawnerZoneEntry(Lot lot, int number, string name)
+        {
+            this.Lot = lot;
+            this.Number = number;
+            this.Name = name;
+        }
+    };
+
+    /// <summary>
+    /// Struct for storing the spawn information for a zone.
+    /// </summary>
+    public struct RandomSpawnerZone
+    {
+        /// <summary>
+        /// Parts of the zone spawning to use.
+        /// </summary>
+        public List<RandomSpawnerZoneEntry> Entries { get; set; }
+
+        /// <summary>
+        /// Weight of the spawning option being selected.
+        /// </summary>
+        public int Chance { get; set; }
+    };
+    
+    /// <summary>
+    /// Base random spawner used in Crux Prime.
+    /// </summary>
+    public abstract class RandomSpawnerBase : ObjectScript
+    {
+        /// <summary>
+        /// Options for spawning zones.
+        /// </summary>
+        public List<RandomSpawnerZone> Zones { get; set; }
+        
+        /// <summary>
+        /// Multipliers for the zones for spawners.
+        /// </summary>
+        public Dictionary<string, float> SectionMultipliers { get; set; }
+        
+        /// <summary>
+        /// Name of the zone.
+        /// </summary>
+        public string ZoneName { get; set; }
+
+        /// <summary>
+        /// Number of enemy deaths to change the spawners at.
+        /// </summary>
+        public int MobDeathResetNumber { get; set; } = 30;
+
+        /// <summary>
+        /// Named enemies to spawn.
+        /// </summary>
+        public static readonly List<Lot> NamedMobs = new List<Lot>()
+        {
+            Lot.CruxPrimeNamedStromling,
+            Lot.CruxPrimeNamedMech,
+            Lot.CruxPrimeNamedSpider,
+            Lot.CruxPrimeNamedPirate,
+            Lot.CruxPrimeNamedAdmiral,
+            Lot.CruxPrimeNamedRonin,
+            Lot.CruxPrimeNamedHorseman,
+        };
+
+        /// <summary>
+        /// Spawners that are being watched for events. To prevent being reconnected.
+        /// </summary>
+        private readonly List<SpawnerNetwork> _spawnersWatched = new List<SpawnerNetwork>();
+
+        /// <summary>
+        /// Randomizer for selecting spawn options.
+        /// </summary>
+        private readonly Random _random = new Random();
+        
+        /// <summary>
+        /// Creates the object script.
+        /// </summary>
+        /// <param name="gameObject">Game object to control with the script.</param>
+        public RandomSpawnerBase(GameObject gameObject) : base(gameObject)
+        {
+            
+        }
+
+        /// <summary>
+        /// Starts the random spawner.
+        /// </summary>
+        public void Start()
+        {
+            this.SetVar("SpawnState", "min");
+            this.SetVar("JustChanged", false);
+            this.SpawnMapZones();
+        }
+
+        /// <summary>
+        /// Spawns the enemy zones.
+        /// </summary>
+        private void SpawnMapZones()
+        {
+            // Spawn the sections.
+            foreach (var (multiplierKey, multiplierValue) in this.SectionMultipliers)
+            {
+                this.SpawnSection("em_" + this.ZoneName + "_" + multiplierKey, multiplierValue);
+            }
+
+            // Spawn a named enemy if the map is correct.
+            if (this.ZoneName == "str")
+            {
+                this.SpawnNamedEnemy();
+            }
+            this.SetVar("bInit", true);
+        }
+
+        /// <summary>
+        /// Spawns a section of the zone.
+        /// </summary>
+        /// <param name="sectionName">Name of the section to spawn.</param>
+        /// <param name="multiplier">Multiplier of the enemies to use.</param>
+        private void SpawnSection(string sectionName, float multiplier)
+        {
+            var spawnLoad = this.GetRandomLoad(sectionName);
+            foreach (var spawnerData in spawnLoad.Entries)
+            {
+                if (spawnerData.Name == "") continue;
+                this.SetSpawnerNetwork(sectionName + "_" + spawnerData.Name, (uint) Math.Floor(spawnerData.Number * multiplier), spawnerData.Lot);
+            }
+        }
+
+        /// <summary>
+        /// Sets a spawner network.
+        /// </summary>
+        /// <param name="spawnerName">Name of the spawner network to set.</param>
+        /// <param name="spawnNumber">Number of the enemies to maintainer.</param>
+        /// <param name="spawnLot">LOT of the enemies to spawn.</param>
+        private void SetSpawnerNetwork(string spawnerName, uint spawnNumber, Lot spawnLot)
+        {
+            // Get the spawner.
+            var spawner = this.GetSpawnerByName(spawnerName);
+            if (spawner == null) return;
+
+            // Ensure only 1 Crux Prime Gorilla can spawn at a time.
+            if (spawnLot == Lot.CruxPrimeGorilla && spawnNumber > 1)
+            {
+                spawnNumber = 1;
+            }
+
+            // Set the LOT and respawn time of the spawner.
+            if (spawnLot != 0)
+            {
+                spawner.SetLot(spawnLot);
+                spawner.SetRespawnTime(80);
+            }
+
+            // Set the number of enemies to maintain.
+            if (spawnNumber != 0)
+            {
+                spawner.SpawnsToMaintain = spawnNumber;
+                spawner.MaxToSpawn = (int) spawnNumber;
+            }
+            
+            // Activate the spawner.
+            if (spawnerName != "Named_Enemies")
+            {
+                spawner.Activate();
+                spawner.SpawnAll();
+            }
+            else
+            {
+                spawner.TrySpawn();
+            }
+
+            // Listen for enemies being smashed.
+            if (this._spawnersWatched.Contains(spawner)) return;
+            this._spawnersWatched.Add(spawner);
+            Listen(spawner.OnRespawnInitiated, (_) =>
+            {
+                this.NotifySpawnerOfDeath(spawner);
+            });
+        }
+
+        /// <summary>
+        /// Gets a random set of enemies to spawn.
+        /// </summary>
+        /// <param name="sectionName">Name of the section.</param>
+        /// <returns>The random set to spawn.</returns>
+        private RandomSpawnerZone GetRandomLoad(string sectionName)
+        {
+            // Get the total weight,
+            var zoneInfo = sectionName.Split('_');
+            var totalWeight = 0;
+            foreach (var zone in this.Zones)
+            {
+                totalWeight += zone.Chance;
+            }
+
+            // Return a random entry.
+            var randomWeight = this._random.Next(0, totalWeight);
+            var weight = 0;
+            foreach (var zone in this.Zones)
+            {
+                weight += zone.Chance;
+                if (randomWeight <= weight)
+                {
+                    return zone;
+                }
+            }
+            return this.Zones[0];
+        }
+
+        /// <summary>
+        /// Event handler for an enemy being smashed.
+        /// </summary>
+        /// <param name="spawner">Spawner the enemy is part of.</param>
+        private void NotifySpawnerOfDeath(SpawnerNetwork spawner)
+        {
+            // Handle the named enemy death.
+            if (spawner.Name == "Named_Enemies")
+            {
+                this.NamedEnemyDeath();
+                return;
+            }
+
+            // Get the current deaths for the current zone.
+            var sectionName = spawner.Name.Substring(0, spawner.Name.Length - 6);
+            var variableName = "mobsDead" + sectionName;
+            var mobDeathCount = this.GetVar<uint>(variableName);
+            mobDeathCount += 1;
+
+            // Change the spawners if the reset number was reached.
+            if (mobDeathCount >= this.MobDeathResetNumber)
+            {
+                var zoneInfo = sectionName.Split('_');
+                this.SpawnSection(sectionName, this.SectionMultipliers[zoneInfo[2]]);
+                mobDeathCount = 0;
+            }
+            
+            // Store the counter.
+            this.SetVar(variableName, mobDeathCount);
+        }
+
+        /// <summary>
+        /// Handles a named enemy being smashed.
+        /// </summary>
+        private void NamedEnemyDeath()
+        {
+            // Start a timer for respawning the named enemy.
+            var respawnDelay = (this._random.NextSingle() + 1.0f) * 450;
+            this.AddTimerWithCancel(respawnDelay, "SpawnNewEnemy");
+        }
+
+        /// <summary>
+        /// Callback for the timer completing.
+        /// </summary>
+        /// <param name="timerName">Timer that was completed.</param>
+        public override void OnTimerDone(string timerName)
+        {
+            if (timerName == "SpawnNewEnemy")
+            {
+                this.SpawnNamedEnemy();
+            }
+        }
+
+        /// <summary>
+        /// Spawns a named enemy.
+        /// </summary>
+        private void SpawnNamedEnemy()
+        {
+            var enemy = NamedMobs[this._random.Next(NamedMobs.Count)];
+            this.SetSpawnerNetwork("Named_Enemies", 1, enemy);
+        }
+    }
+}

--- a/Uchu.StandardScripts/CruxPrime/RandomSpawnerFin.cs
+++ b/Uchu.StandardScripts/CruxPrime/RandomSpawnerFin.cs
@@ -1,0 +1,138 @@
+using System.Collections.Generic;
+using Uchu.World;
+using Uchu.World.Scripting.Native;
+
+namespace Uchu.StandardScripts.CruxPrime {
+
+    /// <summary>
+    /// Native implementation of scripts/02_server/map/am/l_random_spawner_fin.lua
+    /// </summary>
+    [ScriptName("ScriptComponent_1423_script_name__removed")]
+    public class RandomSpawnerFin : RandomSpawnerBase
+    {
+        /// <summary>
+        /// Creates the object script.
+        /// </summary>
+        /// <param name="gameObject">Game object to control with the script.</param>
+        public RandomSpawnerFin(GameObject gameObject) : base(gameObject)
+        {
+            this.Zones = new List<RandomSpawnerZone>()
+            {
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimePirate, 3, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeRonin, 2, "type2"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeSpider, 2, "type4"),
+                    },
+                    Chance = 10,
+                },
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeAdmiral, 3, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeRonin, 2, "type2"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeMech, 2, "type3"),
+                    },
+                    Chance = 5,
+                },
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeHorseman, 2, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeAdmiral, 3, "type2"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeStromling, 5, "type3"),
+                    },
+                    Chance = 10,
+                },
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeHorseman, 1, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeGorilla, 1, "type2"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimePirate, 4, "type3"),
+                    },
+                    Chance = 2,
+                },
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeSpider, 1, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeMech, 2, "type2"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeGorilla, 2, "type3"),
+                    },
+                    Chance = 1,
+                },
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeMech, 2, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimePirate, 4, "type2"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeHorseman, 1, "type3"),
+                    },
+                    Chance = 10,
+                },
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeStromling, 3, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeSpider, 1, "type2"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeHorseman, 1, "type3"),
+                    },
+                    Chance = 5,
+                },
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimePirate, 3, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeAdmiral, 2, "type2"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeGorilla, 1, "type3"),
+                    },
+                    Chance = 2,
+                },
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeStromling, 3, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeMech, 2, "type2"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeSpider, 1, "type3"),
+                    },
+                    Chance = 10,
+                },
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeAdmiral, 3, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimePirate, 1, "type2"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeHorseman, 1, "type3"),
+                    },
+                    Chance = 10,
+                },
+            };
+            this.SectionMultipliers = new Dictionary<string, float>()
+            {
+                { "secA", 1 },
+                { "secB", 1 },
+                { "secC", 1.2f },
+                { "secD", 1.3f },
+                { "secE", 1.6f },
+                { "secF", 1 },
+                { "secG", 1 },
+                { "secH", 1.2f },
+            };
+            this.ZoneName = "fin";
+
+            this.Start();
+        }
+    }
+}

--- a/Uchu.StandardScripts/CruxPrime/RandomSpawnerPit.cs
+++ b/Uchu.StandardScripts/CruxPrime/RandomSpawnerPit.cs
@@ -1,0 +1,143 @@
+using System.Collections.Generic;
+using Uchu.World;
+using Uchu.World.Scripting.Native;
+
+namespace Uchu.StandardScripts.CruxPrime
+{
+    /// <summary>
+    /// Native implementation of scripts/02_server/map/am/l_random_spawner_pit.lua
+    /// </summary>
+    [ScriptName("ScriptComponent_1422_script_name__removed")]
+    public class RandomSpawnerPit : RandomSpawnerBase
+    {
+        /// <summary>
+        /// Creates the object script.
+        /// </summary>
+        /// <param name="gameObject">Game object to control with the script.</param>
+        public RandomSpawnerPit(GameObject gameObject) : base(gameObject)
+        {
+            this.Zones = new List<RandomSpawnerZone>()
+            {
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeAdmiral, 4, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeSpider, 3, "type2"),
+                    },
+                    Chance = 5,
+                },
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeAdmiral, 4, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimePirate, 7, "type2"),
+                    },
+                    Chance = 15,
+                },
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeSpider, 2, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeStromling, 1, "type2"),
+                    },
+                    Chance = 15,
+                },
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeMech, 1, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeHorseman, 4, "type2"),
+                    },
+                    Chance = 6,
+                },
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeGorilla, 1, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeAdmiral, 4, "type2"),
+                    },
+                    Chance = 2,
+                },
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimePirate, 7, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeRonin, 6, "type2"),
+                    },
+                    Chance = 5,
+                },
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeSpider, 3, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeRonin, 9, "type2"),
+                    },
+                    Chance = 10,
+                },
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeGorilla, 1, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeStromling, 8, "type2"),
+                    },
+                    Chance = 2,
+                },
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeMech, 2, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeAdmiral, 4, "type2"),
+                    },
+                    Chance = 2,
+                },
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeHorseman, 2, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeAdmiral, 3, "type2"),
+                    },
+                    Chance = 1,
+                },
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeMech, 3, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeRonin, 5, "type2"),
+                    },
+                    Chance = 15,
+                },
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeMech, 3, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimePirate, 5, "type2"),
+                    },
+                    Chance = 15,
+                },
+            };
+            this.SectionMultipliers = new Dictionary<string, float>()
+            {
+                { "secA", 1 },
+                { "secB", 1.2f },
+                { "secC", 1.2f },
+                { "secD", 1 },
+            };
+            this.ZoneName = "pit";
+            this.MobDeathResetNumber = 20;
+
+            this.Start();
+        }
+    }
+}

--- a/Uchu.StandardScripts/CruxPrime/RandomSpawnerStr.cs
+++ b/Uchu.StandardScripts/CruxPrime/RandomSpawnerStr.cs
@@ -1,0 +1,134 @@
+using System.Collections.Generic;
+using Uchu.World;
+using Uchu.World.Scripting.Native;
+
+namespace Uchu.StandardScripts.CruxPrime
+{
+    /// <summary>
+    /// Native implementation of scripts/02_server/map/am/l_random_spawner_str.lua
+    /// </summary>
+    [ScriptName("ScriptComponent_1420_script_name__removed")]
+    public class RandomSpawnerStr : RandomSpawnerBase
+    {
+        /// <summary>
+        /// Creates the object script.
+        /// </summary>
+        /// <param name="gameObject">Game object to control with the script.</param>
+        public RandomSpawnerStr(GameObject gameObject) : base(gameObject)
+        {
+            this.Zones = new List<RandomSpawnerZone>()
+            {
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeStromling, 4, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimePirate, 3, "type2"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeRonin, 3, "type3"),
+                    },
+                    Chance = 45,
+                },
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeStromling, 3, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimePirate, 3, "type2"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeMech, 3, "type3"),
+                    },
+                    Chance = 20,
+                },
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeStromling, 4, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeAdmiral, 2, "type2"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeSpider, 1, "type3"),
+                    },
+                    Chance = 10,
+                },
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeMech, 3, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeSpider, 1, "type2"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeStromling, 4, "type3"),
+                    },
+                    Chance = 3,
+                },
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeHorseman, 1, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeRonin, 5, "type2"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimePirate, 2, "type3"),
+                    },
+                    Chance = 1,
+                },
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeGorilla, 1, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimePirate, 5, "type2"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeAdmiral, 2, "type3"),
+                    },
+                    Chance = 1,
+                },
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeAdmiral, 2, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeStromling, 4, "type2"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeRonin, 2, "type3"),
+                    },
+                    Chance = 3,
+                },
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeAdmiral, 3, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeGorilla, 1, "type2"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeHorseman, 1, "type3"),
+                    },
+                    Chance = 1,
+                },
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeRonin, 3, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeRonin, 3, "type2"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeRonin, 3, "type3"),
+                    },
+                    Chance = 5,
+                },
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimePirate, 4, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimePirate, 4, "type2"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimePirate, 4, "type3"),
+                    },
+                    Chance = 1,
+                },
+            };
+            this.SectionMultipliers = new Dictionary<string, float>()
+            {
+                { "secA", 1 },
+                { "secB", 1 },
+                { "secC", 1.2f },
+            };
+            this.ZoneName = "str";
+            this.MobDeathResetNumber = 20;
+            
+            this.Start();
+        }
+    }
+}

--- a/Uchu.StandardScripts/CruxPrime/RandomSpawnerZip.cs
+++ b/Uchu.StandardScripts/CruxPrime/RandomSpawnerZip.cs
@@ -1,0 +1,143 @@
+using System.Collections.Generic;
+using Uchu.World;
+using Uchu.World.Scripting.Native;
+
+namespace Uchu.StandardScripts.CruxPrime
+{
+    /// <summary>
+    /// Native implementation of scripts/02_server/map/am/l_random_spawner_zip.lua
+    /// </summary>
+    [ScriptName("ScriptComponent_1421_script_name__removed")]
+    public class RandomSpawnerZip : RandomSpawnerBase
+    {
+        /// <summary>
+        /// Creates the object script.
+        /// </summary>
+        /// <param name="gameObject">Game object to control with the script.</param>
+        public RandomSpawnerZip(GameObject gameObject) : base(gameObject)
+        {
+            this.Zones = new List<RandomSpawnerZone>()
+            {
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeStromling, 3, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimePirate, 2, "type2"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeAdmiral, 2, "type3"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeSpider, 1, "type4"),
+                    },
+                    Chance = 19,
+                },
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeSpider, 1, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimePirate, 2, "type2"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimePirate, 1, "type3"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeAdmiral, 1, "type4"),
+                    },
+                    Chance = 19,
+                },
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeMech, 3, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeStromling, 1, "type2"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimePirate, 1, "type3"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeStromling, 1, "type4"),
+                    },
+                    Chance = 10,
+                },
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeHorseman, 1, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeStromling, 2, "type2"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeRonin, 1, "type3"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimePirate, 1, "type4"),
+                    },
+                    Chance = 5,
+                },
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeGorilla, 1, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeAdmiral, 1, "type2"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeStromling, 2, "type3"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimePirate, 0, "type4"),
+                    },
+                    Chance = 1,
+                },
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeRonin, 2, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeAdmiral, 2, "type2"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeStromling, 2, "type3"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeMech, 1, "type4"),
+                    },
+                    Chance = 19,
+                },
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeSpider, 2, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeStromling, 0, "type2"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeRonin, 0, "type3"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimePirate, 0, "type4"),
+                    },
+                    Chance = 1,
+                },
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimePirate, 4, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeAdmiral, 1, "type2"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeRonin, 0, "type3"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimePirate, 0, "type4"),
+                    },
+                    Chance = 3,
+                },
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeSpider, 1, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeMech, 2, "type2"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeStromling, 2, "type3"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimePirate, 0, "type4"),
+                    },
+                    Chance = 18,
+                },
+                new RandomSpawnerZone
+                {
+                    Entries = new List<RandomSpawnerZoneEntry>()
+                    {
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeHorseman, 1, "type1"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeStromling, 0, "type2"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimeRonin, 2, "type3"),
+                        new RandomSpawnerZoneEntry(Lot.CruxPrimePirate, 0, "type4"),
+                    },
+                    Chance = 1,
+                },
+            };
+            this.SectionMultipliers = new Dictionary<string, float>()
+            {
+                { "secA", 1.2f },
+                { "secB", 1.2f },
+            };
+            this.ZoneName = "zip";
+            this.MobDeathResetNumber = 20;
+            
+            this.Start();
+        }
+    }
+}

--- a/Uchu.StandardScripts/VentureExplorer/CorruptedSentry.cs
+++ b/Uchu.StandardScripts/VentureExplorer/CorruptedSentry.cs
@@ -4,6 +4,8 @@ using Uchu.World.Scripting.Native;
 namespace Uchu.StandardScripts.VentureExplorer
 {
     [ScriptName("ScriptComponent_1075_script_name__removed")]
+    [LotSpecific(Lot.CruxPrimeMech)]
+    [LotSpecific(Lot.CruxPrimeNamedMech)]
     public class CorruptedSentry : ObjectScript
     {
         /// <summary>

--- a/Uchu.World/Objects/Components/Server/SpawnerComponent.cs
+++ b/Uchu.World/Objects/Components/Server/SpawnerComponent.cs
@@ -175,6 +175,19 @@ namespace Uchu.World
                 node.ChangeSpawnTemplate(lot);
             }
         }
+        
+        /// <summary>
+        /// Sets the respawn time of the spawners.
+        /// </summary>
+        /// <param name="respawnTime">Respawn time to use in seconds.</param>
+        public void SetRespawnTime(int respawnTime)
+        {
+            this.RespawnTime = (uint) respawnTime * 1000;
+            foreach (var node in SpawnerNodes)
+            {
+                node.RespawnTime = (int) this.RespawnTime;
+            }
+        }
 
         /// <summary>
         /// Clears the active objects created by the spawner.

--- a/Uchu.World/Structs/Lot.cs
+++ b/Uchu.World/Structs/Lot.cs
@@ -164,6 +164,23 @@ namespace Uchu.World
 
         public const int CrashHelmutNpc = 6374;
 
+        public const int CruxPrimeStromling = 11212;
+        public const int CruxPrimeMech = 11213;
+        public const int CruxPrimeSpider = 11214;
+        public const int CruxPrimePirate = 11215;
+        public const int CruxPrimeAdmiral = 11216;
+        public const int CruxPrimeGorilla = 11217;
+        public const int CruxPrimeRonin = 11218;
+        public const int CruxPrimeHorseman = 11219;
+        
+        public const int CruxPrimeNamedStromling = 11982;
+        public const int CruxPrimeNamedMech = 11983;
+        public const int CruxPrimeNamedSpider = 11984;
+        public const int CruxPrimeNamedPirate = 11985;
+        public const int CruxPrimeNamedAdmiral = 11986;
+        public const int CruxPrimeNamedRonin = 11988;
+        public const int CruxPrimeNamedHorseman = 12654;
+
         #endregion
     }
 }


### PR DESCRIPTION
Closes #229

This pull request implements enemy spawning on Crux Prime. The implementation used is ported over from Darkflame LEGO Universe with some tweaks due to how Uchu works.

Named enemies are included in this implementation.