### PR TITLE
Random Mission Pool

### DIFF
--- a/Uchu.World.Test/Objects/Components/Server/MissionGiverComponentTest.cs
+++ b/Uchu.World.Test/Objects/Components/Server/MissionGiverComponentTest.cs
@@ -146,6 +146,50 @@ namespace Uchu.World.Test.Objects.Components.Server
             this._missionInventoryComponent.AddTestMission(mockMission3.Object);
             Assert.AreEqual(2, this._missionGiverComponent.GetIdMissionToOffer(this._missionInventoryComponent));
         }
+        
+        /// <summary>
+        /// Tests GetIdMissionToOffer with an empty random mission pool.
+        /// </summary>
+        [Test]
+        public void TestGetIdMissionToOfferEmptyRandomPool()
+        {
+            var mockMission = new Mock<MissionInstance>(1, null);
+            mockMission.SetupGet(mission => mission.State).Returns(MissionState.Available);
+            
+            this._missionGiverComponent.Missions = new[]
+            {
+                (new Missions()
+                {
+                    Id = 1,
+                    RandomPool = "",
+                }, this._missionNpcComponent),
+            };
+            this._missionInventoryComponent.AddTestMission(mockMission.Object);
+            Assert.AreEqual(1, this._missionGiverComponent.GetIdMissionToOffer(this._missionInventoryComponent));
+        }
+        
+        /// <summary>
+        /// Tests GetIdMissionToOffer with a random mission pool.
+        /// </summary>
+        [Test]
+        public void TestGetIdMissionToOfferRandomPool()
+        {
+            var mockMission = new Mock<MissionInstance>(1, null);
+            mockMission.SetupGet(mission => mission.State).Returns(MissionState.Available);
+            
+            this._missionGiverComponent.Missions = new[]
+            {
+                (new Missions()
+                {
+                    Id = 1,
+                    IsRandom = true,
+                    RandomPool = "2,3",
+                }, this._missionNpcComponent),
+            };
+            this._missionInventoryComponent.AddTestMission(mockMission.Object);
+            var randomMission = this._missionGiverComponent.GetIdMissionToOffer(this._missionInventoryComponent);
+            Assert.IsTrue(randomMission == 2 || randomMission == 3);
+        }
     }
 }
 

--- a/Uchu.World.Test/Objects/Components/Server/MissionGiverComponentTest.cs
+++ b/Uchu.World.Test/Objects/Components/Server/MissionGiverComponentTest.cs
@@ -1,0 +1,151 @@
+using System;
+using Moq;
+using NUnit.Framework;
+using Uchu.Core;
+using Uchu.Core.Client;
+using Uchu.World.Systems.Missions;
+
+namespace Uchu.World.Test.Objects.Components.Server
+{
+    public class MissionGiverComponentTest
+    {
+        /// <summary>
+        /// Mission giver component used with the tests.
+        /// </summary>
+        private MissionGiverComponent _missionGiverComponent;
+
+        /// <summary>
+        /// Player mission inventory used with the tests.
+        /// </summary>
+        private MissionInventoryComponent _missionInventoryComponent;
+
+        /// <summary>
+        /// Mission NPC component used with the tests.
+        /// </summary>
+        private MissionNPCComponent _missionNpcComponent;
+
+        /// <summary>
+        /// Sets up the tests.
+        /// </summary>
+        [SetUp]
+        public void SetUp()
+        {
+            this._missionGiverComponent = new MissionGiverComponent();
+            this._missionInventoryComponent = new MissionInventoryComponent();
+            this._missionNpcComponent = new MissionNPCComponent()
+            {
+                AcceptsMission = true,
+                OffersMission = true,
+            };
+        }
+        
+        /// <summary>
+        /// Tests GetIdMissionToOffer with no stored missions.
+        /// </summary>
+        [Test]
+        public void TestGetIdMissionToOfferEmpty()
+        {
+            this._missionGiverComponent.Missions = Array.Empty<(Missions, MissionNPCComponent)>();
+            Assert.AreEqual(0, this._missionGiverComponent.GetIdMissionToOffer(this._missionInventoryComponent));
+        }
+        
+        /// <summary>
+        /// Tests GetIdMissionToOffer with a stored mission with the default id.
+        /// </summary>
+        [Test]
+        public void TestGetIdMissionToOfferDefaultMissionId()
+        {
+            this._missionGiverComponent.Missions = new[]
+            {
+                (new Missions() { Id = default, }, this._missionNpcComponent)
+            };
+            Assert.AreEqual(0, this._missionGiverComponent.GetIdMissionToOffer(this._missionInventoryComponent));
+        }
+        
+        /// <summary>
+        /// Tests GetIdMissionToOffer with a stored mission but missions aren't offered.
+        /// </summary>
+        [Test]
+        public void TestGetIdMissionToOfferDoesntOfferMission()
+        {
+            this._missionNpcComponent.OffersMission = false;
+            this._missionGiverComponent.Missions = new[]
+            {
+                (new Missions() { Id = 1, }, this._missionNpcComponent)
+            };
+            Assert.AreEqual(0, this._missionGiverComponent.GetIdMissionToOffer(this._missionInventoryComponent));
+        }
+        
+        /// <summary>
+        /// Tests GetIdMissionToOffer with a mission ready to complete taking priority.
+        /// </summary>
+        [Test]
+        public void TestGetIdMissionToOfferReadyToCompletePriority()
+        {
+            var mockMission1 = new Mock<MissionInstance>(1, null);
+            mockMission1.SetupGet(mission => mission.State).Returns(MissionState.Available);
+            var mockMission2 = new Mock<MissionInstance>(2, null);
+            mockMission2.SetupGet(mission => mission.State).Returns(MissionState.ReadyToComplete);
+            
+            this._missionGiverComponent.Missions = new[]
+            {
+                (new Missions() { Id = 1, }, this._missionNpcComponent),
+                (new Missions() { Id = 2, }, this._missionNpcComponent),
+            };
+            this._missionInventoryComponent.AddTestMission(mockMission1.Object);
+            this._missionInventoryComponent.AddTestMission(mockMission2.Object);
+            Assert.AreEqual(2, this._missionGiverComponent.GetIdMissionToOffer(this._missionInventoryComponent));
+        }
+        
+        /// <summary>
+        /// Tests GetIdMissionToOffer with a mission active taking priority over available.
+        /// </summary>
+        [Test]
+        public void TestGetIdMissionToOfferActivePriority()
+        {
+            var mockMission1 = new Mock<MissionInstance>(1, null);
+            mockMission1.SetupGet(mission => mission.State).Returns(MissionState.Available);
+            var mockMission2 = new Mock<MissionInstance>(2, null);
+            mockMission2.SetupGet(mission => mission.State).Returns(MissionState.Active);
+            var mockMission3 = new Mock<MissionInstance>(1, null);
+            mockMission3.SetupGet(mission => mission.State).Returns(MissionState.Available);
+            
+            this._missionGiverComponent.Missions = new[]
+            {
+                (new Missions() { Id = 1, }, this._missionNpcComponent),
+                (new Missions() { Id = 2, }, this._missionNpcComponent),
+                (new Missions() { Id = 3, }, this._missionNpcComponent),
+            };
+            this._missionInventoryComponent.AddTestMission(mockMission1.Object);
+            this._missionInventoryComponent.AddTestMission(mockMission2.Object);
+            this._missionInventoryComponent.AddTestMission(mockMission3.Object);
+            Assert.AreEqual(2, this._missionGiverComponent.GetIdMissionToOffer(this._missionInventoryComponent));
+        }
+        
+        /// <summary>
+        /// Tests GetIdMissionToOffer with a mission completed active (repeating) taking priority over available.
+        /// </summary>
+        [Test]
+        public void TestGetIdMissionToOfferCompletedActivePriority()
+        {
+            var mockMission1 = new Mock<MissionInstance>(1, null);
+            mockMission1.SetupGet(mission => mission.State).Returns(MissionState.Available);
+            var mockMission2 = new Mock<MissionInstance>(2, null);
+            mockMission2.SetupGet(mission => mission.State).Returns(MissionState.CompletedActive);
+            var mockMission3 = new Mock<MissionInstance>(1, null);
+            mockMission3.SetupGet(mission => mission.State).Returns(MissionState.Available);
+            
+            this._missionGiverComponent.Missions = new[]
+            {
+                (new Missions() { Id = 1, }, this._missionNpcComponent),
+                (new Missions() { Id = 2, }, this._missionNpcComponent),
+                (new Missions() { Id = 3, }, this._missionNpcComponent),
+            };
+            this._missionInventoryComponent.AddTestMission(mockMission1.Object);
+            this._missionInventoryComponent.AddTestMission(mockMission2.Object);
+            this._missionInventoryComponent.AddTestMission(mockMission3.Object);
+            Assert.AreEqual(2, this._missionGiverComponent.GetIdMissionToOffer(this._missionInventoryComponent));
+        }
+    }
+}
+

--- a/Uchu.World.Test/Uchu.World.Test.csproj
+++ b/Uchu.World.Test/Uchu.World.Test.csproj
@@ -7,6 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Moq" Version="4.16.1" />
         <PackageReference Include="NUnit" Version="3.12.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />

--- a/Uchu.World/Objects/Components/Player/MissionInventoryComponent.cs
+++ b/Uchu.World/Objects/Components/Player/MissionInventoryComponent.cs
@@ -43,7 +43,7 @@ namespace Uchu.World
         /// <summary>
         /// Complete list of missions this player has, either active or completed
         /// </summary>
-        private List<MissionInstance> Missions { get; set; }
+        private List<MissionInstance> Missions { get; set; } = new List<MissionInstance>();
 
         /// <summary>
         /// Missions and achievements that the player has that are currently not completed. Provided as an array for
@@ -108,8 +108,6 @@ namespace Uchu.World
                 var missions = await uchuContext.Missions.Where(
                     m => m.CharacterId == GameObject.Id
                 ).ToArrayAsync();
-
-                Missions = new List<MissionInstance>();
                 
                 foreach (var mission in missions)
                 {
@@ -322,6 +320,17 @@ namespace Uchu.World
             }
 
             return mission;
+        }
+
+        /// <summary>
+        /// Adds a mission for unit testing.
+        /// </summary>
+        /// <param name="mission">The test mission to add.</param>
+        public void AddTestMission(MissionInstance mission)
+        {
+            lock (Missions) {
+                Missions.Add(mission);
+            }
         }
 
         /// <summary>

--- a/Uchu.World/Objects/Components/Server/MissionGiverComponent.cs
+++ b/Uchu.World/Objects/Components/Server/MissionGiverComponent.cs
@@ -35,6 +35,11 @@ namespace Uchu.World
         public (Missions, MissionNPCComponent)[] Missions { get; set; }
 
         /// <summary>
+        /// Randomizer for selecting random messages.
+        /// </summary>
+        private Random _random = new Random();
+
+        /// <summary>
         /// Finds all the missions that this giver may offer and stores them
         /// </summary>
         private void CollectMissions()
@@ -150,6 +155,16 @@ namespace Uchu.World
             // Get the mission.
             var mission = this.GetMissionToOffer(missionInventory);
             if (mission == null) return default;
+            
+            // Return a random mission.
+            if ((mission.IsRandom ?? false) && !string.IsNullOrEmpty(mission.RandomPool))
+            {
+                var randomMissions = mission.RandomPool.Split(",");
+                if (int.TryParse(randomMissions[this._random.Next(randomMissions.Length)], out var randomMissionId))
+                {
+                    return randomMissionId;
+                }
+            }
             
             // Return the id.
             return mission.Id ?? default;

--- a/Uchu.World/Systems/Missions/MissionInstance.cs
+++ b/Uchu.World/Systems/Missions/MissionInstance.cs
@@ -202,7 +202,7 @@ namespace Uchu.World.Systems.Missions
         /// <summary>
         /// The current state of this mission for the player
         /// </summary>
-        public MissionState State { get; private set; }
+        public virtual MissionState State { get; private set; }
         
         /// <summary>
         /// Whether the player may repeat this mission


### PR DESCRIPTION
This pull request adds support for missions that use a pool of random missions. This is mainly visible for Crux Prime where the daily mission giver at Point Zeta uses random missions instead of fixed missions.

As part of my academic requirements, unit testing was included as part of this pull request.