### PR TITLE
Check Prerequisites for Mission Task Progress

### DIFF
--- a/Uchu.World/Client/CdClient/MissionParser.cs
+++ b/Uchu.World/Client/CdClient/MissionParser.cs
@@ -42,7 +42,7 @@ namespace Uchu.World.Client
             }
             
             var id = int.Parse(str);
-            return playerMissions.Any(c => c.MissionId == id);
+            return playerMissions.Any(c => c.MissionId == id && c.Completed);
         }
 
         public static bool CheckPrerequiredMissions(string missions, MissionInstance[] playerMissions)

--- a/Uchu.World/Systems/Missions/MissionTaskInstance.cs
+++ b/Uchu.World/Systems/Missions/MissionTaskInstance.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Uchu.Core;
 using Uchu.Core.Client;
+using Uchu.World.Client;
 
 namespace Uchu.World.Systems.Missions
 {
@@ -191,6 +192,7 @@ namespace Uchu.World.Systems.Missions
         /// </example>
         protected void AddProgress(float value)
         {
+            if (this.Mission.Player.TryGetComponent<MissionInventoryComponent>(out var missionInventoryComponent) && !MissionParser.CheckPrerequiredMissions(this.Mission.PrerequisiteMissions, missionInventoryComponent.AllMissions)) return;
             Progress.Add(value);
             MessageUpdateMissionTask();
         }


### PR DESCRIPTION
Closes #198

This pull request adds a mission requisite check for progressing mission tasks.
I tested this from start to the mission with the Maelstrom vacuum and completed various achievements to make sure they don't start early.