### PR TITLE
Fix Pet Cove Story Plaques

### DIFF
--- a/Uchu.StandardScripts/General/NexusForcePlaque.cs
+++ b/Uchu.StandardScripts/General/NexusForcePlaque.cs
@@ -23,6 +23,8 @@ namespace Uchu.StandardScripts.General
             var idString = (string) text;
             var id = int.Parse(idString.Substring(idString.Length - 2));
             var flag = 10000 + Zone.ZoneId + id;
+            if (gameObject.Settings.TryGetValue("altFlagID", out var altFlagId))
+                flag = (int) altFlagId;
                 
             // Set the flag for players who interact with the plaque.
             Listen(gameObject.OnInteract, async player =>


### PR DESCRIPTION
For a school assignment, I decided to look at the Pet Cove Story Plaques issue (#271). the bug is due to a special case that is not accounted for in the handler of the plaque being interacted with.