### PR TITLE
Ignore Ghosting Filter for Gnarled Forest Special Case

### DIFF
--- a/Uchu.World/Objects/GameObjects/GameObject.cs
+++ b/Uchu.World/Objects/GameObjects/GameObject.cs
@@ -120,6 +120,8 @@ namespace Uchu.World
 
         public ReplicaComponent[] ReplicaComponents => Components.OfType<ReplicaComponent>().ToArray();
 
+        public int TotalReplicaComponents => Components.OfType<ReplicaComponent>().Count();
+
         public Player[] Viewers => Zone.Players.Where(p => p.Perspective.TryGetNetworkId(this, out _)).ToArray();
 
         #endregion
@@ -353,7 +355,17 @@ namespace Uchu.World
             result = GetComponents<T>();
             return result.Length != default;
         }
+        
+        public bool HasComponent(Type type)
+        {
+            return GetComponent(type) != default;
+        }
 
+        public bool HasComponent<T>() where T : Component
+        {
+            return GetComponent<T>() != default;
+        }
+        
         public void RemoveComponent(Type type)
         {
             var comp = GetComponent(type);

--- a/Uchu.World/Objects/Perspective/Filters/RenderDistanceFilter.cs
+++ b/Uchu.World/Objects/Perspective/Filters/RenderDistanceFilter.cs
@@ -42,7 +42,13 @@ namespace Uchu.World.Filters
         /// <returns>Whether the object passes the render distance check.</returns>
         public bool View(GameObject gameObject)
         {
-            if (gameObject?.Transform == default)
+            if (gameObject == default)
+                return false;
+
+            if (gameObject.TotalReplicaComponents == 3 && gameObject.HasComponent<SimplePhysicsComponent>() && gameObject.HasComponent<RendererComponent>() && gameObject.HasComponent<TriggerComponent>())
+                return true;
+            
+            if (gameObject.Transform == default)
                 return false;
 
             if (gameObject is Player)


### PR DESCRIPTION
Closes #264

This pull request attempts to resolve Brig Rock loading late with a [fairly simple workaround used by DLU](https://github.com/DarkflameUniverse/DarkflameServer/blob/80a09881c097a07520914b4f73ea1aa7970baba7/dGame/Entity.cpp#L738).  Ideally, a more complex check should be done based on the distance to the boundary of the object. However, this is a lot simpler and is *probably* fine with more recent hardware.