### PR TITLE
Improve user feedback for chat filter

### DIFF
--- a/Uchu.World/Packets/Server/ChatModerationResponsePacket.cs
+++ b/Uchu.World/Packets/Server/ChatModerationResponsePacket.cs
@@ -28,7 +28,7 @@ namespace Uchu.World
             writer.Write(ChatChannel);
             writer.Write(ChatMode);
 
-            writer.WriteString(PlayerName, 33, true);
+            writer.WriteString(PlayerName, 42, true);
 
             foreach (var (start, length) in UnacceptedRanges)
             {
@@ -36,7 +36,7 @@ namespace Uchu.World
                 writer.Write(length);
             }
 
-            for (var i = 0; i < 32 - UnacceptedRanges.Length; i++)
+            for (var i = 0; i < 64 - UnacceptedRanges.Length; i++)
             {
                 writer.Write<byte>(0);
                 writer.Write<byte>(0);

--- a/Uchu.World/Social/Whitelist.cs
+++ b/Uchu.World/Social/Whitelist.cs
@@ -115,7 +115,7 @@ namespace Uchu.World.Social
                 if (allowed) continue;
 
                 // Add the bad word's position and length.
-                var position = (byte) phrase.IndexOf(word, StringComparison.Ordinal);
+                var position = (byte) (phrase.Substring(match.Index).IndexOf(word, StringComparison.Ordinal) + match.Index);
                 redact.Add((position, (byte) word.Length));
             }
 


### PR DESCRIPTION
Small fix to improve the feedback users get when their message doesn't get past the chat filter. (See [lu_packets](https://lcdruniverse.org/lu_packets/lu_packets/world/client/struct.ChatModerationString.html), [DLU](https://github.com/DarkflameUniverse/DarkflameServer/blob/main/dNet/WorldPackets.cpp#L199) for reference.)

Before:
![image](https://github.com/UchuServer/Uchu/assets/11255568/19599af0-595b-4e4f-974b-154e2edda80c)

After:
![image](https://github.com/UchuServer/Uchu/assets/11255568/b146a5e6-f925-486e-9834-63d5a2d529a3)
