### PR TITLE
Fix respawning for racing

### DIFF
--- a/Uchu.World/Objects/Components/ReplicaComponents/RacingControlComponent.cs
+++ b/Uchu.World/Objects/Components/ReplicaComponents/RacingControlComponent.cs
@@ -230,9 +230,11 @@ namespace Uchu.World
             RacingPlayerInfo playerInfo;
 
             if (IsPlayerRegistered(player)) {
-                playerInfo = Players.Find(info => info.Player.Id == player.Id);
+                var playerInfoIndex = Players.FindIndex(info => info.Player.Id == player.Id);
+                playerInfo = Players[playerInfoIndex];
                 playerInfo.Player = player;
                 playerInfo.PlayerLoaded = true;
+                Players[playerInfoIndex] = playerInfo;
             } else {
                 playerInfo = new RacingPlayerInfo
                 {

--- a/Uchu.World/Objects/Components/ReplicaComponents/RacingControlComponent.cs
+++ b/Uchu.World/Objects/Components/ReplicaComponents/RacingControlComponent.cs
@@ -378,8 +378,10 @@ namespace Uchu.World
                 VehicleId = car,
             });
 
-            var playerInfo = Players.Find(info => info.Player.Id == player.Id);
-            playerInfo.Vehicle = car;
+            var playerInfoIndex = Players.FindIndex(info => info.Player.Id == player.Id);
+            var tempInfo = Players[playerInfoIndex];
+            tempInfo.Vehicle = car;
+            Players[playerInfoIndex] = tempInfo;
         }
 
         private void InitRace()


### PR DESCRIPTION
The previous code
```c#
var playerInfo = Players.Find(info => info.Player.Id == player.Id);
playerInfo.Vehicle = car;
```
was broken because `Players` contains `RacingPlayerInfo` structs, which is a value type, not a reference type. This means that `var playerInfo = ...` results in a local copy of the data. The following line then only modifies this local copy, leaving `Players` unchanged.

This new code creates a local copy of the data, modifies it, and then updates the struct stored in the `Players` list.