### PR TITLE
Fix skill used in imagination crate script

### DIFF
--- a/Uchu.StandardScripts/Racing/ImaginationCrate.cs
+++ b/Uchu.StandardScripts/Racing/ImaginationCrate.cs
@@ -18,7 +18,7 @@ public class ImaginationCrate : ObjectScript
                 return;
             
             var skillComponent = car.GetComponent<SkillComponent>();
-            skillComponent.CalculateSkillAsync(585, car);
+            skillComponent.CalculateSkillAsync(586, car);
         });
     }
 }


### PR DESCRIPTION
Should be skill 586 instead of 585, reference: https://explorer.lu-dev.net/scripts/ai/racing/objects/race_imagine_crate_server.lua

(As a result, the full racing imagination bar is filled instead of only 1/6 points)